### PR TITLE
Dev into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 My creation of custom components fro ESP home.
 
 ### Recent updates
-18-03-2022 - WavinAhc9000v2 - Added a file for comfort temperature for channel 1. Only for testing. HAVENT TESTED MY SELF AS I DONT HAVE A THERMOSTAT WITH IR. Please report back if working or not
-16-03-2022 - WavinAhc9000v2 - Inspired by Jopand's work on the nilan custom component I have created an updated version for Wavin Ahc 9000, utilizing the esphome modbus_controller and alot of esphome lambda (Thank you for not using standard modbus function Wavin!)
-02-03-2022 - Genvexv2 - Inspired by Jopand's work on the nilan custom component I have created an updated version for Genvex, utilizing the esphome modbus_controller
+18-03-2022 - WavinAhc9000v2 - Added a file for comfort temperature for channel 1. Only for testing. HAVENT TESTED MY SELF AS I DONT HAVE A THERMOSTAT WITH IR. Please report back if working or not.
+16-03-2022 - WavinAhc9000v2 - Inspired by Jopand's work on the nilan custom component I have created an updated version for Wavin Ahc 9000, utilizing the esphome modbus_controller and alot of esphome lambda (Thank you for not using standard modbus function Wavin!).
+02-03-2022 - Genvexv2 - Inspired by Jopand's work on the nilan custom component I have created an updated version for Genvex, utilizing the esphome modbus_controller.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ My creation of custom components fro ESP home.
 
 ### Recent updates
 18-03-2022 - WavinAhc9000v2 - Added a file for comfort temperature for channel 1. Only for testing. HAVENT TESTED MY SELF AS I DONT HAVE A THERMOSTAT WITH IR. Please report back if working or not.
+
 16-03-2022 - WavinAhc9000v2 - Inspired by Jopand's work on the nilan custom component I have created an updated version for Wavin Ahc 9000, utilizing the esphome modbus_controller and alot of esphome lambda (Thank you for not using standard modbus function Wavin!).
+
 02-03-2022 - Genvexv2 - Inspired by Jopand's work on the nilan custom component I have created an updated version for Genvex, utilizing the esphome modbus_controller.
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 My creation of custom components fro ESP home.
 
 ### Recent updates
+21-03-2022 - WavinAhc9000v2 - A big thanks to nic6911 https://github.com/nic6911 for testing the comfort temperature config file and providing config files for confort for all the channels
+
 18-03-2022 - WavinAhc9000v2 - Added a file for comfort temperature for channel 1. Only for testing. HAVENT TESTED MY SELF AS I DONT HAVE A THERMOSTAT WITH IR. Please report back if working or not.
 
 16-03-2022 - WavinAhc9000v2 - Inspired by Jopand's work on the nilan custom component I have created an updated version for Wavin Ahc 9000, utilizing the esphome modbus_controller and alot of esphome lambda (Thank you for not using standard modbus function Wavin!).
@@ -94,22 +96,38 @@ packages:
     url: https://github.com/heinekmadsen/esphome_components
     ref: main
     files: 
-      - components/wavinahc9000v2/configs/channel_01.yaml 
-      - components/wavinahc9000v2/configs/channel_02.yaml 
-      - components/wavinahc9000v2/configs/channel_03.yaml 
+      - components/wavinahc9000v2/configs/channel_01.yaml
+      - components/wavinahc9000v2/configs/channel_01_comfort.yaml # Only for channels with thermostat with IR sensor
+      - components/wavinahc9000v2/configs/channel_02.yaml
+      - components/wavinahc9000v2/configs/channel_02_comfort.yaml # Only for channels with thermostat with IR sensor
+      - components/wavinahc9000v2/configs/channel_03.yaml
+      - components/wavinahc9000v2/configs/channel_03_comfort.yaml # Only for channels with thermostat with IR sensor
       - components/wavinahc9000v2/configs/channel_04.yaml 
+      - components/wavinahc9000v2/configs/channel_04_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_05.yaml 
+      #- components/wavinahc9000v2/configs/channel_05_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_06.yaml 
+      #- components/wavinahc9000v2/configs/channel_06_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_07.yaml 
+      #- components/wavinahc9000v2/configs/channel_07_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_08.yaml 
+      #- components/wavinahc9000v2/configs/channel_08_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_09.yaml 
+      #- components/wavinahc9000v2/configs/channel_09_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_10.yaml 
+      #- components/wavinahc9000v2/configs/channel_10_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_11.yaml 
+      #- components/wavinahc9000v2/configs/channel_11_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_12.yaml
+      #- components/wavinahc9000v2/configs/channel_12_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_13.yaml 
+      #- components/wavinahc9000v2/configs/channel_13_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_14.yaml
+      #- components/wavinahc9000v2/configs/channel_14_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_15.yaml 
+      #- components/wavinahc9000v2/configs/channel_15_comfort.yaml # Only for channels with thermostat with IR sensor
       #- components/wavinahc9000v2/configs/channel_16.yaml 
+      #- components/wavinahc9000v2/configs/channel_16_comfort.yaml # Only for channels with thermostat with IR sensor
     refresh: 0s
 
 uart:

--- a/components/genvexv2/climate/genvexv2_climate.cpp
+++ b/components/genvexv2/climate/genvexv2_climate.cpp
@@ -122,7 +122,7 @@ climate::ClimateTraits Genvexv2Climate::traits() {
    });
 
   traits.set_supports_current_temperature(true);
-  traits.set_visual_temperature_step(1);
+  traits.set_visual_temperature_step(0.1);
   traits.set_visual_min_temperature(5);
   traits.set_visual_max_temperature(30);
 

--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -367,6 +367,6 @@ binary_sensor:
 climate:
   - platform: genvexv2
     name: Genvex
-    current_temp_sensor_id: genvex_temp_t1
+    current_temp_sensor_id: genvex_temp_t7
     target_temp_sensor_id: genvex_target_temp
     fan_speed_sensor_id: genvex_ventilation_speed

--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -1,5 +1,8 @@
 external_components:
-  - source: github://heinekmadsen/esphome_components
+  - source: 
+      type: git
+      url: https://github.com/heinekmadsen/esphome_components
+      ref: dev
     refresh: 0s
     components: [genvexv2]
 

--- a/components/wavinahc9000v2/climate/__init__.py
+++ b/components/wavinahc9000v2/climate/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, sensor, switch, number
+from esphome.components import climate, sensor, switch, number, binary_sensor
 from .. import Wavinahc9000v2, CONF_WAVINAHC9000v2_ID
 from esphome.const import (
     CONF_ID
@@ -9,6 +9,7 @@ from esphome.const import (
 CONF_TARGET_TEMP = "target_temp_number_id"
 CONF_CURRENT_TEMP = "current_temp_sensor_id"
 CONF_MODE = "mode_switch_sensor_id"
+CONF_ACTION = "action_sensor_id"
 
 wavinahc9000v2_ns = cg.esphome_ns.namespace('wavinahc9000v2')
 Wavinahc9000v2Climate = wavinahc9000v2_ns.class_('Wavinahc9000v2Climate', climate.Climate, cg.Component)
@@ -18,7 +19,8 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend({
     cv.GenerateID(CONF_WAVINAHC9000v2_ID): cv.use_id(Wavinahc9000v2),
     cv.Required(CONF_TARGET_TEMP): cv.use_id(number.Number),
     cv.Required(CONF_CURRENT_TEMP): cv.use_id(sensor.Sensor),
-    cv.Required(CONF_MODE): cv.use_id(switch.Switch)
+    cv.Required(CONF_MODE): cv.use_id(switch.Switch),
+    cv.Required(CONF_ACTION): cv.use_id(binary_sensor.BinarySensor),
 }).extend(cv.COMPONENT_SCHEMA)
 
 def to_code(config):
@@ -34,3 +36,6 @@ def to_code(config):
 
     switch_mode = yield cg.get_variable(config[CONF_MODE])
     cg.add(var.set_mode_switch(switch_mode))
+
+    hvac_action = yield cg.get_variable(config[CONF_ACTION])
+    cg.add(var.set_hvac_action(hvac_action))

--- a/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
+++ b/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
@@ -27,6 +27,16 @@ void Wavinahc9000v2Climate::setup() {
     }
     publish_state();
   });
+  hvac_action_->add_on_state_callback([this](bool state) {
+    ESP_LOGD(TAG, "Current action is : %s", ONOFF(state));
+    if (state) {
+      this->action = climate::CLIMATE_ACTION_HEATING;
+    }
+    else if (!state) {
+      this->action = climate::CLIMATE_ACTION_OFF;
+    }
+    publish_state();
+  });
 
   current_temperature = current_temp_sensor_->state;
   target_temperature  = temp_setpoint_number_->state;
@@ -69,6 +79,8 @@ climate::ClimateTraits Wavinahc9000v2Climate::traits() {
     climate::ClimateMode::CLIMATE_MODE_OFF,
     climate::ClimateMode::CLIMATE_MODE_AUTO,
   });
+
+  traits.set_supports_action(true);
 
   traits.set_supports_current_temperature(true);
   traits.set_visual_temperature_step(0.1);

--- a/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
+++ b/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
@@ -33,7 +33,7 @@ void Wavinahc9000v2Climate::setup() {
       this->action = climate::CLIMATE_ACTION_HEATING;
     }
     else if (!state) {
-      this->action = climate::CLIMATE_ACTION_OFF;
+      this->action = climate::CLIMATE_ACTION_IDLE;
     }
     publish_state();
   });

--- a/components/wavinahc9000v2/climate/wavinahc9000v2_climate.h
+++ b/components/wavinahc9000v2/climate/wavinahc9000v2_climate.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/modbus_controller/modbus_controller.h"
@@ -29,6 +30,10 @@ public:
     this->mode_switch_ = switch_;
   }
 
+  void set_hvac_action(binary_sensor::BinarySensor *binary_sensor) {
+    this->hvac_action_ = binary_sensor;
+  }
+
 
 protected:
   /// Override control to change settings of the climate device.
@@ -45,6 +50,9 @@ protected:
 
   /// The select component used for getting the operation mode
   switch_::Switch *mode_switch_{ nullptr };
+
+  /// The select component used for getting the current action
+  binary_sensor::BinarySensor *hvac_action_{ nullptr };
 
 private:
 };

--- a/components/wavinahc9000v2/configs/basic.yaml
+++ b/components/wavinahc9000v2/configs/basic.yaml
@@ -1,0 +1,10 @@
+external_components:
+  - source: github://heinekmadsen/esphome_components
+    refresh: 0s
+    ref: dev
+    components: [wavinahc9000v2]
+
+  # PR required until merged into main
+  - source: github://pr#3295
+    components: [modbus_controller]
+    refresh: 0s

--- a/components/wavinahc9000v2/configs/basic.yaml
+++ b/components/wavinahc9000v2/configs/basic.yaml
@@ -8,3 +8,5 @@ external_components:
   - source: github://pr#3295
     components: [modbus_controller]
     refresh: 0s
+
+wavinahc9000v2:

--- a/components/wavinahc9000v2/configs/channel_01.yaml
+++ b/components/wavinahc9000v2/configs/channel_01.yaml
@@ -36,6 +36,21 @@ sensor:
     filters:
       - multiply: 10 
 
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_01_friendly_name}
+    id:                     ${device}_output_${channel_01_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x00 # channel 01 (00)
+      - 0x01
+    bitmask: 0x0010
+
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -114,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_01_id}
     target_temp_number_id:  ${device}_target_temp_${channel_01_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_01_id}
+    action_sensor_id:       ${device}_output_${channel_01_id}

--- a/components/wavinahc9000v2/configs/channel_01.yaml
+++ b/components/wavinahc9000v2/configs/channel_01.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_01_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_01_comfort.yaml
@@ -1,5 +1,3 @@
-# !!!ONLY FOR THE BAVE FOR TESTING!!! #
-
 external_components:
   - source: github://heinekmadsen/esphome_components
     refresh: 0s
@@ -62,8 +60,8 @@ number:
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
-    name:                   ${name} Standby ${channel_01_friendly_name}
-    id:                     ${device}_standby_${channel_01_id}
+    name:                   ${name} Comfort Standby ${channel_01_friendly_name}
+    id:                     ${device}_comfort_standby_${channel_01_id}
     modbus_controller_id:   ${device}_modbus_controller
     custom_command:
       - 0x01
@@ -105,7 +103,7 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
-    name:                   ${name} ${channel_01_friendly_name}
+    name:                   ${name} Comfort ${channel_01_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_01_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_01_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_01_id}

--- a/components/wavinahc9000v2/configs/channel_01_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_01_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_02.yaml
+++ b/components/wavinahc9000v2/configs/channel_02.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_02_friendly_name}
+    id:                     ${device}_output_${channel_02_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x01 # channel 02 (01)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_02_id}
     target_temp_number_id:  ${device}_target_temp_${channel_02_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_02_id}
+    action_sensor_id:       ${device}_output_${channel_02_id}

--- a/components/wavinahc9000v2/configs/channel_02_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_02_comfort.yaml
@@ -1,14 +1,4 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
 
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_03.yaml
+++ b/components/wavinahc9000v2/configs/channel_03.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_03_friendly_name}
+    id:                     ${device}_output_${channel_03_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x02 # channel 03 (02)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_03_id}
     target_temp_number_id:  ${device}_target_temp_${channel_03_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_03_id}
+    action_sensor_id:       ${device}_output_${channel_03_id}

--- a/components/wavinahc9000v2/configs/channel_03_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_03_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_04.yaml
+++ b/components/wavinahc9000v2/configs/channel_04.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_04_friendly_name}
+    id:                     ${device}_output_${channel_04_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x03 # channel 04 (03)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_04_id}
     target_temp_number_id:  ${device}_target_temp_${channel_04_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_04_id}
+    action_sensor_id:       ${device}_output_${channel_04_id}

--- a/components/wavinahc9000v2/configs/channel_04_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_04_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_05.yaml
+++ b/components/wavinahc9000v2/configs/channel_05.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_05_friendly_name}
+    id:                     ${device}_output_${channel_05_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x04 # channel 05 (04)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_05_id}
     target_temp_number_id:  ${device}_target_temp_${channel_05_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_05_id}
+    action_sensor_id:       ${device}_output_${channel_05_id}

--- a/components/wavinahc9000v2/configs/channel_05_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_05_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_06.yaml
+++ b/components/wavinahc9000v2/configs/channel_06.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,36 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_06_friendly_name}
+    id:                     ${device}_output_${channel_06_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x05 # channel 06 (05)
+      - 0x01
+    bitmask: 0x0010
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_06_friendly_name}
+    id:                     ${device}_output_${channel_06_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x05 # channel 06 (05)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +144,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_06_id}
     target_temp_number_id:  ${device}_target_temp_${channel_06_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_06_id}
+    action_sensor_id:       ${device}_output_${channel_06_id}

--- a/components/wavinahc9000v2/configs/channel_06.yaml
+++ b/components/wavinahc9000v2/configs/channel_06.yaml
@@ -51,21 +51,6 @@ binary_sensor:
       - 0x01
     bitmask: 0x0010
 
-# ----------- Binary ----------- #
-binary_sensor:
-  - platform:               modbus_controller
-    name:                   ${name} Output ${channel_06_friendly_name}
-    id:                     ${device}_output_${channel_06_id}
-    modbus_controller_id:   ${device}_modbus_controller
-    custom_command:
-      - 0x01
-      - 0x43
-      - 0x03
-      - 0x00
-      - 0x05 # channel 06 (05)
-      - 0x01
-    bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_06_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_06_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_07.yaml
+++ b/components/wavinahc9000v2/configs/channel_07.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_07_friendly_name}
+    id:                     ${device}_output_${channel_07_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x06 # channel 07 (06)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_07_id}
     target_temp_number_id:  ${device}_target_temp_${channel_07_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_07_id}
+    action_sensor_id:       ${device}_output_${channel_07_id}

--- a/components/wavinahc9000v2/configs/channel_07_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_07_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_08.yaml
+++ b/components/wavinahc9000v2/configs/channel_08.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_08_friendly_name}
+    id:                     ${device}_output_${channel_08_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x07 # channel 08 (07)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_08_id}
     target_temp_number_id:  ${device}_target_temp_${channel_08_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_08_id}
+    action_sensor_id:       ${device}_output_${channel_08_id}

--- a/components/wavinahc9000v2/configs/channel_08_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_08_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_09.yaml
+++ b/components/wavinahc9000v2/configs/channel_09.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_09_friendly_name}
+    id:                     ${device}_output_${channel_09_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x08 # channel 09 (08)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_09_id}
     target_temp_number_id:  ${device}_target_temp_${channel_09_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_09_id}
+    action_sensor_id:       ${device}_output_${channel_09_id}

--- a/components/wavinahc9000v2/configs/channel_09_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_09_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_10.yaml
+++ b/components/wavinahc9000v2/configs/channel_10.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_10_friendly_name}
+    id:                     ${device}_output_${channel_10_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x09 # channel 10 (09)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_10_id}
     target_temp_number_id:  ${device}_target_temp_${channel_10_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_10_id}
+    action_sensor_id:       ${device}_output_${channel_10_id}

--- a/components/wavinahc9000v2/configs/channel_10_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_10_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_11.yaml
+++ b/components/wavinahc9000v2/configs/channel_11.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_11_friendly_name}
+    id:                     ${device}_output_${channel_11_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x0A # channel 11 (0A)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_11_id}
     target_temp_number_id:  ${device}_target_temp_${channel_11_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_11_id}
+    action_sensor_id:       ${device}_output_${channel_11_id}

--- a/components/wavinahc9000v2/configs/channel_11_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_11_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_12.yaml
+++ b/components/wavinahc9000v2/configs/channel_12.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_12_friendly_name}
+    id:                     ${device}_output_${channel_12_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x0B # channel 12 (0B)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_12_id}
     target_temp_number_id:  ${device}_target_temp_${channel_12_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_12_id}
+    action_sensor_id:       ${device}_output_${channel_12_id}

--- a/components/wavinahc9000v2/configs/channel_12_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_12_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_13.yaml
+++ b/components/wavinahc9000v2/configs/channel_13.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_13_friendly_name}
+    id:                     ${device}_output_${channel_13_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x0C # channel 13 (0C)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_13_id}
     target_temp_number_id:  ${device}_target_temp_${channel_13_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_13_id}
+    action_sensor_id:       ${device}_output_${channel_13_id}

--- a/components/wavinahc9000v2/configs/channel_13_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_13_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_14.yaml
+++ b/components/wavinahc9000v2/configs/channel_14.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_14_friendly_name}
+    id:                     ${device}_output_${channel_14_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x0D # channel 14 (0D)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_14_id}
     target_temp_number_id:  ${device}_target_temp_${channel_14_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_14_id}
+    action_sensor_id:       ${device}_output_${channel_14_id}

--- a/components/wavinahc9000v2/configs/channel_14_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_14_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_15.yaml
+++ b/components/wavinahc9000v2/configs/channel_15.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_15_friendly_name}
+    id:                     ${device}_output_${channel_15_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x0E # channel 15 (0E)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_15_id}
     target_temp_number_id:  ${device}_target_temp_${channel_15_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_15_id}
+    action_sensor_id:       ${device}_output_${channel_15_id}

--- a/components/wavinahc9000v2/configs/channel_15_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_15_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_16.yaml
+++ b/components/wavinahc9000v2/configs/channel_16.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller
@@ -46,6 +35,21 @@ sensor:
     device_class: battery
     filters:
       - multiply: 10 
+
+# ----------- Binary ----------- #
+binary_sensor:
+  - platform:               modbus_controller
+    name:                   ${name} Output ${channel_16_friendly_name}
+    id:                     ${device}_output_${channel_16_id}
+    modbus_controller_id:   ${device}_modbus_controller
+    custom_command:
+      - 0x01
+      - 0x43
+      - 0x03
+      - 0x00
+      - 0x0F # channel 16 (0F)
+      - 0x01
+    bitmask: 0x0010
 
 # ----------- Number ----------- #
 number:
@@ -125,3 +129,4 @@ climate:
     current_temp_sensor_id: ${device}_temp_${channel_16_id}
     target_temp_number_id:  ${device}_target_temp_${channel_16_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_16_id}
+    action_sensor_id:       ${device}_output_${channel_16_id}

--- a/components/wavinahc9000v2/configs/channel_16_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_16_comfort.yaml
@@ -1,14 +1,3 @@
-external_components:
-  - source: github://heinekmadsen/esphome_components
-    refresh: 0s
-    components: [wavinahc9000v2]
-
-  # PR required until merged into main
-  - source: github://pr#3295
-    components: [modbus_controller]
-    refresh: 0s
-
-wavinahc9000v2:
 # ----------- Sensor ----------- #
 sensor:
   - platform:               modbus_controller


### PR DESCRIPTION
Adding features:
WavinAhc9000v2:
 - Support for Comfort temperature (Creates a new climate entity for comfort
 - Added support for Climate action to reflect the current output status for the channel. Will show idle if not heating and heat if heating
 - Optimizing the config files for faster compilation - BREAKING CHANGE ADD THE basic.yaml to the list of packages.
 
 Genvexv2
 - Changed current temp for climate to T7 as T1 drops when bypass opens
 - Changed to show .1 degrees