### PR TITLE
Feature/add id and visual settings to all channels

### DIFF
--- a/components/wavinahc9000v2/configs/channel_01.yaml
+++ b/components/wavinahc9000v2/configs/channel_01.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_01_id}
     name:                   ${name} ${channel_01_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_01_id}
     target_temp_number_id:  ${device}_target_temp_${channel_01_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_01_id}
     action_sensor_id:       ${device}_output_${channel_01_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_01_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_01_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_01_id}
     name:                   ${name} Comfort ${channel_01_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_01_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_01_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_01_id}
     action_sensor_id:       ${device}_output_${channel_01_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_02.yaml
+++ b/components/wavinahc9000v2/configs/channel_02.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_02_id}
     name:                   ${name} ${channel_02_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_02_id}
     target_temp_number_id:  ${device}_target_temp_${channel_02_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_02_id}
     action_sensor_id:       ${device}_output_${channel_02_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_02_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_02_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_02_id}
     name:                   ${name} Comfort ${channel_02_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_02_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_02_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_02_id}
     action_sensor_id:       ${device}_output_${channel_02_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_03.yaml
+++ b/components/wavinahc9000v2/configs/channel_03.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_03_id}
     name:                   ${name} ${channel_03_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_03_id}
     target_temp_number_id:  ${device}_target_temp_${channel_03_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_03_id}
     action_sensor_id:       ${device}_output_${channel_03_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_03_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_03_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_03_id}
     name:                   ${name} Comfort ${channel_03_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_03_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_03_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_03_id}
     action_sensor_id:       ${device}_output_${channel_03_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_04.yaml
+++ b/components/wavinahc9000v2/configs/channel_04.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_04_id}
     name:                   ${name} ${channel_04_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_04_id}
     target_temp_number_id:  ${device}_target_temp_${channel_04_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_04_id}
     action_sensor_id:       ${device}_output_${channel_04_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_04_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_04_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_04_id}
     name:                   ${name} Comfort ${channel_04_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_04_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_04_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_04_id}
     action_sensor_id:       ${device}_output_${channel_04_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_05.yaml
+++ b/components/wavinahc9000v2/configs/channel_05.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_05_id}
     name:                   ${name} ${channel_05_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_05_id}
     target_temp_number_id:  ${device}_target_temp_${channel_05_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_05_id}
     action_sensor_id:       ${device}_output_${channel_05_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_05_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_05_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_05_id}
     name:                   ${name} Comfort ${channel_05_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_05_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_05_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_05_id}
     action_sensor_id:       ${device}_output_${channel_05_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_06.yaml
+++ b/components/wavinahc9000v2/configs/channel_06.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_06_id}
     name:                   ${name} ${channel_06_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_06_id}
     target_temp_number_id:  ${device}_target_temp_${channel_06_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_06_id}
     action_sensor_id:       ${device}_output_${channel_06_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_06_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_06_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_06_id}
     name:                   ${name} Comfort ${channel_06_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_06_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_06_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_06_id}
     action_sensor_id:       ${device}_output_${channel_06_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_07.yaml
+++ b/components/wavinahc9000v2/configs/channel_07.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_07_id}
     name:                   ${name} ${channel_07_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_07_id}
     target_temp_number_id:  ${device}_target_temp_${channel_07_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_07_id}
     action_sensor_id:       ${device}_output_${channel_07_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_07_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_07_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_07_id}
     name:                   ${name} Comfort ${channel_07_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_07_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_07_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_07_id}
     action_sensor_id:       ${device}_output_${channel_07_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_08.yaml
+++ b/components/wavinahc9000v2/configs/channel_08.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_08_id}
     name:                   ${name} ${channel_08_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_08_id}
     target_temp_number_id:  ${device}_target_temp_${channel_08_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_08_id}
     action_sensor_id:       ${device}_output_${channel_08_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_08_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_08_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_08_id}
     name:                   ${name} Comfort ${channel_08_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_08_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_08_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_08_id}
     action_sensor_id:       ${device}_output_${channel_08_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_09.yaml
+++ b/components/wavinahc9000v2/configs/channel_09.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_09_id}
     name:                   ${name} ${channel_09_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_09_id}
     target_temp_number_id:  ${device}_target_temp_${channel_09_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_09_id}
     action_sensor_id:       ${device}_output_${channel_09_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_09_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_09_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_09_id}
     name:                   ${name} Comfort ${channel_09_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_09_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_09_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_09_id}
     action_sensor_id:       ${device}_output_${channel_09_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_10.yaml
+++ b/components/wavinahc9000v2/configs/channel_10.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_10_id}
     name:                   ${name} ${channel_10_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_10_id}
     target_temp_number_id:  ${device}_target_temp_${channel_10_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_10_id}
     action_sensor_id:       ${device}_output_${channel_10_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_10_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_10_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_10_id}
     name:                   ${name} Comfort ${channel_10_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_10_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_10_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_10_id}
     action_sensor_id:       ${device}_output_${channel_10_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_11.yaml
+++ b/components/wavinahc9000v2/configs/channel_11.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_11_id}
     name:                   ${name} ${channel_11_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_11_id}
     target_temp_number_id:  ${device}_target_temp_${channel_11_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_11_id}
     action_sensor_id:       ${device}_output_${channel_11_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_11_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_11_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_11_id}
     name:                   ${name} Comfort ${channel_11_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_11_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_11_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_11_id}
     action_sensor_id:       ${device}_output_${channel_11_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_12.yaml
+++ b/components/wavinahc9000v2/configs/channel_12.yaml
@@ -126,8 +126,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_12_id}
     name:                   ${name} ${channel_12_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_12_id}
     target_temp_number_id:  ${device}_target_temp_${channel_12_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_12_id}
     action_sensor_id:       ${device}_output_${channel_12_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_12_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_12_comfort.yaml
@@ -92,8 +92,14 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_12_id}
     name:                   ${name} Comfort ${channel_12_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_12_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_12_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_12_id}
     action_sensor_id:       ${device}_output_${channel_12_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1
+

--- a/components/wavinahc9000v2/configs/channel_13.yaml
+++ b/components/wavinahc9000v2/configs/channel_13.yaml
@@ -125,8 +125,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_13_id}
     name:                   ${name} ${channel_13_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_13_id}
     target_temp_number_id:  ${device}_target_temp_${channel_13_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_13_id}
     action_sensor_id:       ${device}_output_${channel_13_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_13_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_13_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_13_id}
     name:                   ${name} Comfort ${channel_13_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_13_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_13_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_13_id}
     action_sensor_id:       ${device}_output_${channel_13_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_14.yaml
+++ b/components/wavinahc9000v2/configs/channel_14.yaml
@@ -125,8 +125,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_14_id}
     name:                   ${name} ${channel_14_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_14_id}
     target_temp_number_id:  ${device}_target_temp_${channel_14_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_14_id}
     action_sensor_id:       ${device}_output_${channel_14_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_14_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_14_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_14_id}
     name:                   ${name} Comfort ${channel_14_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_14_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_14_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_14_id}
     action_sensor_id:       ${device}_output_${channel_14_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_15.yaml
+++ b/components/wavinahc9000v2/configs/channel_15.yaml
@@ -125,8 +125,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_15_id}
     name:                   ${name} ${channel_15_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_15_id}
     target_temp_number_id:  ${device}_target_temp_${channel_15_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_15_id}
     action_sensor_id:       ${device}_output_${channel_15_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_15_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_15_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_15_id}
     name:                   ${name} Comfort ${channel_15_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_15_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_15_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_15_id}
     action_sensor_id:       ${device}_output_${channel_15_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_16.yaml
+++ b/components/wavinahc9000v2/configs/channel_16.yaml
@@ -125,8 +125,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_16_id}
     name:                   ${name} ${channel_16_friendly_name}
     current_temp_sensor_id: ${device}_temp_${channel_16_id}
     target_temp_number_id:  ${device}_target_temp_${channel_16_id}
     mode_switch_sensor_id:  ${device}_standby_${channel_16_id}
     action_sensor_id:       ${device}_output_${channel_16_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1

--- a/components/wavinahc9000v2/configs/channel_16_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_16_comfort.yaml
@@ -92,8 +92,13 @@ switch:
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2
+    id:                     ${device}_climate_${channel_16_id}
     name:                   ${name} Comfort ${channel_16_friendly_name}
     current_temp_sensor_id: ${device}_comfort_temp_${channel_16_id}
     target_temp_number_id:  ${device}_comfort_target_temp_${channel_16_id}
     mode_switch_sensor_id:  ${device}_comfort_standby_${channel_16_id}
     action_sensor_id:       ${device}_output_${channel_16_id}
+    visual:
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1


### PR DESCRIPTION
Added ID to all climate entities.
This enables using !extend and !remove of these entities, which does require an ID (https://esphome.io/guides/configuration-types.html#extend)

Added visual settings to each channel. Setting set temperature step to 0.5 and current temperature step to 0.1