### PR TITLE
Updated for ESPHome 2025.6.5+ Compatibility

### DIFF
--- a/components/wavinahc9000v2/climate/__init__.py
+++ b/components/wavinahc9000v2/climate/__init__.py
@@ -14,7 +14,7 @@ CONF_ACTION = "action_sensor_id"
 wavinahc9000v2_ns = cg.esphome_ns.namespace('wavinahc9000v2')
 Wavinahc9000v2Climate = wavinahc9000v2_ns.class_('Wavinahc9000v2Climate', climate.Climate, cg.Component)
 
-CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend({
+CONFIG_SCHEMA = climate.climate_schema(Wavinahc9000v2Climate).extend({
     cv.GenerateID(): cv.declare_id(Wavinahc9000v2Climate),
     cv.GenerateID(CONF_WAVINAHC9000v2_ID): cv.use_id(Wavinahc9000v2),
     cv.Required(CONF_TARGET_TEMP): cv.use_id(number.Number),

--- a/components/wavinahc9000v2/configs/basic.yaml
+++ b/components/wavinahc9000v2/configs/basic.yaml
@@ -1,17 +1,17 @@
 external_components:
   - source: 
       type: git
-      url: https://github.com/heinekmadsen/esphome_components
+      url: https://github.com/ricobach/esphome_components
       ref: main
     refresh: 0s
     components: [wavinahc9000v2]
   # ESPHome 2022.6 has updates for modbus/modbus_controller which makes writing a number back to the wavin device fail.
   # This ensures it uses the components from 2022.5.1 instead. A work around until I figure out how to make 2022.6 work.
-  - source:
-      type: git
-      url: https://github.com/esphome/esphome
-      ref: 2022.5.1
-    components: [ modbus, modbus_controller ]
-    refresh: 0s
+  #  - source:
+  #    type: git
+  #    url: https://github.com/esphome/esphome
+  #    ref: 2022.5.1
+  #  components: [ modbus, modbus_controller ]
+  #  refresh: 0s
 
 wavinahc9000v2:

--- a/components/wavinahc9000v2/configs/basic.yaml
+++ b/components/wavinahc9000v2/configs/basic.yaml
@@ -1,17 +1,9 @@
 external_components:
   - source: 
       type: git
-      url: https://github.com/ricobach/esphome_components
+      url: https://github.com/heinekmadsen/esphome_components
       ref: main
     refresh: 0s
     components: [wavinahc9000v2]
-  # ESPHome 2022.6 has updates for modbus/modbus_controller which makes writing a number back to the wavin device fail.
-  # This ensures it uses the components from 2022.5.1 instead. A work around until I figure out how to make 2022.6 work.
-  #  - source:
-  #    type: git
-  #    url: https://github.com/esphome/esphome
-  #    ref: 2022.5.1
-  #  components: [ modbus, modbus_controller ]
-  #  refresh: 0s
 
 wavinahc9000v2:

--- a/components/wavinahc9000v2/configs/channel_01.yaml
+++ b/components/wavinahc9000v2/configs/channel_01.yaml
@@ -42,7 +42,7 @@ sensor:
     lambda: |-
       uint16_t raw_battery = (data[2] << 8) | data[3];
       ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_batt * 10;
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller

--- a/components/wavinahc9000v2/configs/channel_01.yaml
+++ b/components/wavinahc9000v2/configs/channel_01.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_01_friendly_name}
     id:                     ${device}_battery_${channel_01_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_batt * 10;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_01
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_01}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_02.yaml
+++ b/components/wavinahc9000v2/configs/channel_02.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_02_friendly_name}
     id:                     ${device}_battery_${channel_02_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_02
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_02}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_03.yaml
+++ b/components/wavinahc9000v2/configs/channel_03.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_03_friendly_name}
     id:                     ${device}_battery_${channel_03_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_03
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_03}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_04.yaml
+++ b/components/wavinahc9000v2/configs/channel_04.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_04_friendly_name}
     id:                     ${device}_battery_${channel_04_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_04
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_04}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_05.yaml
+++ b/components/wavinahc9000v2/configs/channel_05.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_05_friendly_name}
     id:                     ${device}_battery_${channel_05_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_05
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_05}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_06.yaml
+++ b/components/wavinahc9000v2/configs/channel_06.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_06_friendly_name}
     id:                     ${device}_battery_${channel_06_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_06
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_06}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_07.yaml
+++ b/components/wavinahc9000v2/configs/channel_07.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_07_friendly_name}
     id:                     ${device}_battery_${channel_07_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_07
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_07}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_08.yaml
+++ b/components/wavinahc9000v2/configs/channel_08.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_08_friendly_name}
     id:                     ${device}_battery_${channel_08_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_08
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_08}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_09.yaml
+++ b/components/wavinahc9000v2/configs/channel_09.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_09_friendly_name}
     id:                     ${device}_battery_${channel_09_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_09
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_09}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -94,7 +101,7 @@ switch:
       - $channel_09
       - 0x01
     write_lambda: |-
-      ESP_LOGD("main","Modbus Switch incoming state for channel 09 = %s",ONOFF(x));
+      ESP_LOGD("main","Modbus Switch incoming state for channel 01 = %s",ONOFF(x));
       bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
@@ -120,9 +127,8 @@ switch:
       return true;
     lambda: |-
       int mode = data[1];
-      ESP_LOGD("main","MODE for Channel 09 is: %i",mode);    
+      ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_10.yaml
+++ b/components/wavinahc9000v2/configs/channel_10.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_10_friendly_name}
     id:                     ${device}_battery_${channel_10_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_10
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_10}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -94,7 +101,7 @@ switch:
       - $channel_10
       - 0x01
     write_lambda: |-
-      ESP_LOGD("main","Modbus Switch incoming state for channel 10 = %s",ONOFF(x));
+      ESP_LOGD("main","Modbus Switch incoming state for channel 01 = %s",ONOFF(x));
       bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
@@ -120,9 +127,8 @@ switch:
       return true;
     lambda: |-
       int mode = data[1];
-      ESP_LOGD("main","MODE for Channel 10 is: %i",mode);    
+      ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_11.yaml
+++ b/components/wavinahc9000v2/configs/channel_11.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_11_friendly_name}
     id:                     ${device}_battery_${channel_11_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_11
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_11}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_12.yaml
+++ b/components/wavinahc9000v2/configs/channel_12.yaml
@@ -16,9 +16,14 @@ sensor:
     accuracy_decimals: 1
     device_class: temperature
     force_update: True
-    filters:
-      - multiply: 0.1
-  # Battery
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_12_friendly_name}
     id:                     ${device}_battery_${channel_12_id}
@@ -34,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -51,7 +57,6 @@ binary_sensor:
       - $channel_12
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -71,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_12}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -122,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_13.yaml
+++ b/components/wavinahc9000v2/configs/channel_13.yaml
@@ -15,9 +15,15 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
-  # Battery
+    force_update: True
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_13_friendly_name}
     id:                     ${device}_battery_${channel_13_id}
@@ -33,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -50,7 +57,6 @@ binary_sensor:
       - $channel_13
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -70,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_13}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -121,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_14.yaml
+++ b/components/wavinahc9000v2/configs/channel_14.yaml
@@ -15,9 +15,15 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
-  # Battery
+    force_update: True
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_14_friendly_name}
     id:                     ${device}_battery_${channel_14_id}
@@ -33,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -50,7 +57,6 @@ binary_sensor:
       - $channel_14
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -70,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_14}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -121,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_15.yaml
+++ b/components/wavinahc9000v2/configs/channel_15.yaml
@@ -15,9 +15,15 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
-  # Battery
+    force_update: True
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_15_friendly_name}
     id:                     ${device}_battery_${channel_15_id}
@@ -33,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -50,7 +57,6 @@ binary_sensor:
       - $channel_15
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -70,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_15}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -121,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2

--- a/components/wavinahc9000v2/configs/channel_16.yaml
+++ b/components/wavinahc9000v2/configs/channel_16.yaml
@@ -15,9 +15,15 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
-  # Battery
+    force_update: True
+    lambda: |-
+      for (int i = 0; i < data.size(); i++) {
+        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
+      return raw_temp * 0.1;
+# ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_16_friendly_name}
     id:                     ${device}_battery_${channel_16_id}
@@ -33,9 +39,10 @@ sensor:
     unit_of_measurement: "%"
     accuracy_decimals: 1
     device_class: battery
-    filters:
-      - multiply: 10 
-
+    lambda: |-
+      uint16_t raw_battery = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
+      return raw_battery * 10.0;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -50,7 +57,6 @@ binary_sensor:
       - $channel_16
       - 0x01
     bitmask: 0x0010
-
 # ----------- Number ----------- #
 number:
   - platform:               modbus_controller
@@ -70,15 +76,17 @@ number:
     max_value: 40
     step: .5
     write_lambda: |-
-      ESP_LOGD("main", "Trying to write new target temp: %f",x);
+      ESP_LOGD("DEBUG", "Trying to write new target temp: %f", x);
       uint16_t targettemp = x * 10;
       payload.push_back(0x0144);
       payload.push_back(0x0200);
       payload.push_back(${channel_16}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
-
+    lambda: |-
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
+      return raw_temp * 0.1;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -121,7 +129,6 @@ switch:
       int mode = data[1];
       ESP_LOGD("main","MODE for Channel 01 is: %i",mode);    
       return mode;
-
 # ----------- Climate ----------- #
 climate:
   - platform:               wavinahc9000v2


### PR DESCRIPTION
Replaced deprecated usage of climate.CLIMATE_SCHEMA with the new climate.climate_schema() approach, as required starting from ESPHome 2025.6.

Reworked the component to ensure compatibility with the latest ESPHome modbus and modbus_controller implementations.
Previously, this integration only worked with modbus and modbus_controller version 2022.5.1.
This update brings full support for current and future ESPHome versions.

This should resolve:
#38, #40, #16.

Tested and verified working with:
ESPHome 2025.6.3.