### PR TITLE
Fix resolution for wavinahc9000v2

### DIFF
--- a/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
+++ b/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
@@ -80,7 +80,8 @@ climate::ClimateTraits Wavinahc9000v2Climate::traits() {
   });
 
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
-  traits.set_visual_temperature_step(0.5);
+  traits.set_visual_current_temperature_step(0.1);
+  traits.set_visual_target_temperature_step(0.5);
   traits.set_visual_min_temperature(6);
   traits.set_visual_max_temperature(40);
 


### PR DESCRIPTION
The Wavin AHC9000 has target temperature resolution of 0.5 C, but measures temperatures in 0.1 C.

This PR enables the full resolution of the temperature sensors, without sacrificing the correctness of setting the target temperature.