### PR TITLE
genvexv2: Fix HA climate card set target temp and esphome to_string() compile error

### DIFF
--- a/components/genvexv2/climate/__init__.py
+++ b/components/genvexv2/climate/__init__.py
@@ -15,7 +15,6 @@ genvexv2_ns = cg.esphome_ns.namespace('genvexv2')
 Genvexv2Climate = genvexv2_ns.class_('Genvexv2Climate', climate.Climate, cg.Component)
  
 CONFIG_SCHEMA = climate.climate_schema(Genvexv2Climate).extend({
-    cv.GenerateID(): cv.declare_id(Genvexv2Climate),
     cv.GenerateID(CONF_GENVEXV2_ID): cv.use_id(Genvexv2),
     cv.Required(CONF_TARGET_TEMP): cv.use_id(number.Number),
     cv.Required(CONF_CURRENT_TEMP): cv.use_id(sensor.Sensor),

--- a/components/genvexv2/climate/genvexv2_climate.cpp
+++ b/components/genvexv2/climate/genvexv2_climate.cpp
@@ -26,6 +26,7 @@ void Genvexv2Climate::setup() {
   current_temperature = current_temp_sensor_->state;
   target_temperature  = temp_setpoint_number_->state;
   genvexv2fanspeed_to_fanmode(fan_speed_number_->state);
+  publish_state();
 }
 
 void Genvexv2Climate::control(const climate::ClimateCall& call) {
@@ -55,10 +56,10 @@ void Genvexv2Climate::control(const climate::ClimateCall& call) {
         fan_speed_number_->make_call().set_value(0).perform();//set(0);
         break;
       }
-      case climate::CLIMATE_MODE_AUTO: 
+      case climate::CLIMATE_MODE_HEAT_COOL:
       {
-        ESP_LOGD("TAG", "Mode changed to AUTO");
-        this->custom_fan_mode = esphome::to_string("2");
+        ESP_LOGD("TAG", "Mode changed to HEAT_COOL");
+        this->custom_fan_mode = esphome::to_string(2);
         fan_mode.reset();
         auto optional_genvexv2_fan_mode = parse_number<float>("2");
         if(optional_genvexv2_fan_mode.has_value())
@@ -118,10 +119,11 @@ climate::ClimateTraits Genvexv2Climate::traits() {
 
   traits.set_supported_modes({
     climate::ClimateMode::CLIMATE_MODE_OFF,
-    climate::ClimateMode::CLIMATE_MODE_AUTO,
+    climate::ClimateMode::CLIMATE_MODE_HEAT_COOL,
    });
 
   traits.set_supports_current_temperature(true);
+  traits.set_supports_two_point_target_temperature(false);
   traits.set_visual_temperature_step(0.1);
   traits.set_visual_min_temperature(5);
   traits.set_visual_max_temperature(30);
@@ -144,22 +146,22 @@ void Genvexv2Climate::genvexv2fanspeed_to_fanmode(const int state)
   switch (state) {
   case 1:
     ESP_LOGD("TAG", "Case 1");
-    this->mode = climate::CLIMATE_MODE_AUTO;
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     this->custom_fan_mode = esphome::to_string(state);
     break;
   case 2:
     ESP_LOGD("TAG", "Case 2");
-    this->mode = climate::CLIMATE_MODE_AUTO;
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     this->custom_fan_mode = esphome::to_string(state);
     break;
   case 3:
     ESP_LOGD("TAG", "Case 3");
-    this->mode = climate::CLIMATE_MODE_AUTO;
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     this->custom_fan_mode = esphome::to_string(state);
     break;
   case 4:
     ESP_LOGD("TAG", "Case 4");
-    this->mode = climate::CLIMATE_MODE_AUTO;
+    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
     this->custom_fan_mode = esphome::to_string(state);
     break;
   case 0:


### PR DESCRIPTION
First of all thank you for this component!

I've been using it to control Genvex Premium Preheat 250 / Optima301
Lately i've had some esphome compilation errors and issues with the climate card not showing set temp buttons.

Changes:
1. Remove duplicate cv.GenerateID() in climate/__init__.py
Already handled by climate_schema

2. Fix to_string("2") compilation error - changed to to_string(2)
to_string wasn't passing strings

3. Add publish_state() at end of setup() to expose target temp to HA

4. Change AUTO mode to HEAT_COOL mode for HA Climate card compatibility
When mode AUTO, set temp buttons was missing

5. Add traits.set_supports_two_point_target_temperature(false)
I think this is required by HEAT_COOL, set to false as only one setpoint needed.

Result: No compilation errors, Climate card now shows temperature control buttons in Home Assistant.

Tested with ESPHome 2025.10.4, Home Assistant 2025.10.4, ESP32-S2
```yaml
esp32:
  board: lolin_s2_mini
  framework: 
    type: esp-idf
```
** NOTE **
Not tested with framework arduino as it's near deprecation time