### PR TITLE
Add icons and units of measure for Genvex sensors

### DIFF
--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -182,6 +182,7 @@ sensor:
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex humidity fan control"
     id: genvex_humidity_fan_control
+    icon: mdi:water-percent
     unit_of_measurement: "%"
     value_type: U_WORD
     register_type: read


### PR DESCRIPTION
- Add missing icons
- Change danish name to english
- Add device_class
- Add missing unit_of_measurement

Originally implemented by @lskov:
https://github.com/lskov/esphome_components