### PR TITLE
Add missing Genvex modbus controller sensors for configurations for inlet/outlet speed modes and bypass temperature settings

### DIFF
--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -356,7 +356,117 @@ number:
     step: 1.0
     address: 100
 
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 1 Inlet Speed"
+    id: genvex_step1_inlet_speed
+    icon: mdi:fan-speed-1
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 6
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 2 Inlet Speed"
+    id: genvex_step2_inlet_speed
+    icon: mdi:fan-speed-2
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 7
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 3 Inlet Speed"
+    id: genvex_step3_inlet_speed
+    icon: mdi:fan-speed-3
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 8
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 1 Outlet Speed"
+    id: genvex_step1_outlet_speed
+    icon: mdi:fan-speed-1
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 9
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 2 Outlet Speed"
+    id: genvex_step2_outlet_speed
+    icon: mdi:fan-speed-2
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 10
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 3 Outlet Speed"
+    id: genvex_step3_outlet_speed
+    icon: mdi:fan-speed-3
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 11
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Bypass Open Max Temp"
+    id: genvex_bypass_open_max_temp
+    icon: mdi:thermometer
+    unit_of_measurement: °C
+    min_value: 1
+    max_value: 10
+    register_type: holding
+    value_type: U_WORD
+    address: 17
+    step: 0.1
+    lambda: "return x/10;"
+    write_lambda: |-
+      ESP_LOGD("Genvex target temp","Processing new bypass max open temp %d", x);
+      uint16_t new_temp = (x * 100)/10;
+      ESP_LOGD("Genvex target temp","New value %d", new_temp);
+      return new_temp;
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Bypass Close on Low Inlet Temp (Diff From Target Temp)"
+    id: bypass_close_on_low_inlet_temp
+    icon: mdi:thermometer
+    unit_of_measurement: °C
+    min_value: 0
+    max_value: 20
+    register_type: holding
+    value_type: U_WORD
+    address: 25
+
 binary_sensor:
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex On/Off Possible On K1"
+    id: genvex_on_off_possible
+    register_type: holding
+    address: 24
+
   - platform: modbus_controller
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex bypass onoff"


### PR DESCRIPTION
Originally implemented by @lskov:
https://github.com/lskov/esphome_components