### PR TITLE
Add icons and units of measure for Genvex sensors

### DIFF
--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -182,6 +182,7 @@ sensor:
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex humidity fan control"
     id: genvex_humidity_fan_control
+    icon: mdi:water-percent
     unit_of_measurement: "%"
     value_type: U_WORD
     register_type: read

--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -41,7 +41,9 @@ select:
     
 sensor:
   - platform: template
-    name: "Genvex Virkningsgrad"
+    name: "Genvex Efficiency"
+    icon: mdi:air-filter
+    unit_of_measurement: "%"
     lambda: |-
       float genvex_temp_t1_inlet = (id(genvex_temp_t1).state);
       float genvex_temp_t3_outdoor = (id(genvex_temp_t3).state);
@@ -142,6 +144,7 @@ sensor:
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex inlet fan"
     id: genvex_inlet_fan
+    icon: mdi:fan
     unit_of_measurement: "%"
     value_type: U_WORD
     register_type: read
@@ -151,6 +154,7 @@ sensor:
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex extract fan"
     id: genvex_extract_fan
+    icon: mdi:fan
     unit_of_measurement: "%"
     value_type: U_WORD
     register_type: read
@@ -337,6 +341,9 @@ number:
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex target temp"
     id: genvex_target_temp
+    device_class: temperature
+    icon: mdi:thermometer
+    unit_of_measurement: °C
     min_value: 10
     max_value: 30
     step: 0.1
@@ -351,6 +358,7 @@ number:
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex Ventilation speed"
     id: genvex_ventilation_speed
+    icon: mdi:fan
     min_value: 0
     max_value: 4
     step: 1.0


### PR DESCRIPTION
- Add missing icons
- Change danish name to english
- Add device_class
- Add missing unit_of_measurement

Originally implemented by @lskov:
https://github.com/lskov/esphome_components