### PR TITLE
Fix wavinahc9000v2: compiler warnings, temperature validation, and lambda return values

### DIFF
--- a/components/wavinahc9000v2/__init__.py
+++ b/components/wavinahc9000v2/__init__.py
@@ -41,6 +41,6 @@ CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(Wavinahc9000v2),   
 })
 
-def to_code(config):
+async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    yield cg.register_component(var, config) 
+    await cg.register_component(var, config)

--- a/components/wavinahc9000v2/climate/__init__.py
+++ b/components/wavinahc9000v2/climate/__init__.py
@@ -23,19 +23,19 @@ CONFIG_SCHEMA = climate.climate_schema(Wavinahc9000v2Climate).extend({
     cv.Required(CONF_ACTION): cv.use_id(binary_sensor.BinarySensor),
 }).extend(cv.COMPONENT_SCHEMA)
 
-def to_code(config):
+async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    yield cg.register_component(var, config)
-    yield climate.register_climate(var, config)
+    await cg.register_component(var, config)
+    await climate.register_climate(var, config)
 
-    number_set_temp = yield cg.get_variable(config[CONF_TARGET_TEMP])
+    number_set_temp = await cg.get_variable(config[CONF_TARGET_TEMP])
     cg.add(var.set_temp_setpoint_number(number_set_temp))
 
-    sens_current_temp = yield cg.get_variable(config[CONF_CURRENT_TEMP])
+    sens_current_temp = await cg.get_variable(config[CONF_CURRENT_TEMP])
     cg.add(var.set_current_temp_sensor(sens_current_temp))
 
-    switch_mode = yield cg.get_variable(config[CONF_MODE])
+    switch_mode = await cg.get_variable(config[CONF_MODE])
     cg.add(var.set_mode_switch(switch_mode))
 
-    hvac_action = yield cg.get_variable(config[CONF_ACTION])
+    hvac_action = await cg.get_variable(config[CONF_ACTION])
     cg.add(var.set_hvac_action(hvac_action))

--- a/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
+++ b/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
@@ -4,7 +4,7 @@
 
 namespace esphome {
 namespace wavinahc9000v2 {
-static const char *TAG = "wavinahc9000v2.climate";
+static const char *const TAG = "wavinahc9000v2.climate";
 
 void Wavinahc9000v2Climate::setup() {
   current_temp_sensor_->add_on_state_callback([this](float state) {
@@ -22,7 +22,7 @@ void Wavinahc9000v2Climate::setup() {
     if (state) {
       this->mode = climate::CLIMATE_MODE_OFF;
     }
-    else if (!state) {
+    else {
       this->mode = climate::CLIMATE_MODE_HEAT;
     }
     publish_state();
@@ -32,7 +32,7 @@ void Wavinahc9000v2Climate::setup() {
     if (state) {
       this->action = climate::CLIMATE_ACTION_HEATING;
     }
-    else if (!state) {
+    else {
       this->action = climate::CLIMATE_ACTION_IDLE;
     }
     publish_state();

--- a/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
+++ b/components/wavinahc9000v2/climate/wavinahc9000v2_climate.cpp
@@ -79,9 +79,7 @@ climate::ClimateTraits Wavinahc9000v2Climate::traits() {
     climate::ClimateMode::CLIMATE_MODE_HEAT,
   });
 
-  traits.set_supports_action(true);
-
-  traits.set_supports_current_temperature(true);
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
   traits.set_visual_temperature_step(0.5);
   traits.set_visual_min_temperature(6);
   traits.set_visual_max_temperature(40);

--- a/components/wavinahc9000v2/configs/basic.yaml
+++ b/components/wavinahc9000v2/configs/basic.yaml
@@ -1,8 +1,8 @@
 external_components:
   - source: 
       type: git
-      url: https://github.com/nic6911/esphome_components
-      ref: feature/ahc9000v2update
+      url: https://github.com/heinekmadsen/esphome_components
+      ref: main
     refresh: 0s
     components: [wavinahc9000v2]
 

--- a/components/wavinahc9000v2/configs/basic.yaml
+++ b/components/wavinahc9000v2/configs/basic.yaml
@@ -1,8 +1,8 @@
 external_components:
   - source: 
       type: git
-      url: https://github.com/heinekmadsen/esphome_components
-      ref: main
+      url: https://github.com/nic6911/esphome_components
+      ref: feature/ahc9000v2update
     refresh: 0s
     components: [wavinahc9000v2]
 

--- a/components/wavinahc9000v2/configs/channel_01.yaml
+++ b/components/wavinahc9000v2/configs/channel_01.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_01
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_01_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_01.yaml
+++ b/components/wavinahc9000v2/configs/channel_01.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_01_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_01
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_01_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 01 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 01: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_01_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_01_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -24,6 +34,7 @@ number:
     name:                   ${name} Comfort Target Temperature ${channel_01_friendly_name}
     id:                     ${device}_comfort_target_temp_${channel_01_id}
     modbus_controller_id:   ${device}_modbus_controller
+    internal: true
     custom_command: 
       - 0x01
       - 0x43
@@ -31,7 +42,6 @@ number:
       - 0x01 # 01 = comfort
       - $channel_01
       - 0x01
-      internal: true
     value_type: U_WORD
     unit_of_measurement: "°C"
     min_value: 6
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_01}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 01 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 01: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_01_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_01_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_02.yaml
+++ b/components/wavinahc9000v2/configs/channel_02.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_02
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_02_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_02.yaml
+++ b/components/wavinahc9000v2/configs/channel_02.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_02_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_02
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_02_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 02 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 02: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_02_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_02_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_02}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 02 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 02: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_02_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_02_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_03.yaml
+++ b/components/wavinahc9000v2/configs/channel_03.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_03_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_03
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_03_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 03 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 03: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_03.yaml
+++ b/components/wavinahc9000v2/configs/channel_03.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_03
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_03_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_03_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_03_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_03}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 03 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 03: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_03_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_03_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_04.yaml
+++ b/components/wavinahc9000v2/configs/channel_04.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_04_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_04
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_04_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 04 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 04: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_04.yaml
+++ b/components/wavinahc9000v2/configs/channel_04.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_04
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_04_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_04_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_04_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_04}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 04 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 04: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_04_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_04_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_05.yaml
+++ b/components/wavinahc9000v2/configs/channel_05.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_05
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_05_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_05.yaml
+++ b/components/wavinahc9000v2/configs/channel_05.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_05_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_05
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_05_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 05 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 05: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_05_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_05_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_05}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 05 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 05: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_05_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_05_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_06.yaml
+++ b/components/wavinahc9000v2/configs/channel_06.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_06_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_06
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_06_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 06 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 06: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_06.yaml
+++ b/components/wavinahc9000v2/configs/channel_06.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_06
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_06_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_06_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_06_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_06}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 06 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 06: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_06_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_06_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_07.yaml
+++ b/components/wavinahc9000v2/configs/channel_07.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_07
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_07_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_07.yaml
+++ b/components/wavinahc9000v2/configs/channel_07.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_07_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_07
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_07_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 07 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 07: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_07_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_07_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_07}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 07 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 07: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_07_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_07_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_08.yaml
+++ b/components/wavinahc9000v2/configs/channel_08.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_08
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_08_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_08.yaml
+++ b/components/wavinahc9000v2/configs/channel_08.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_08_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_08
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_08_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 08 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 08: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_08_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_08_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_08}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 08 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 08: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_08_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_08_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_09.yaml
+++ b/components/wavinahc9000v2/configs/channel_09.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_09
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_09_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_09.yaml
+++ b/components/wavinahc9000v2/configs/channel_09.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_09_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_09
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_09_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 09 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 09: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_09_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_09_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_09}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 09 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 09: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_09_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_09_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_10.yaml
+++ b/components/wavinahc9000v2/configs/channel_10.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_10_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_10
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_10_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 10 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 10: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_10.yaml
+++ b/components/wavinahc9000v2/configs/channel_10.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_10
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_10_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_10_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_10_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_10}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 10 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 10: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_10_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_10_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_11.yaml
+++ b/components/wavinahc9000v2/configs/channel_11.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_11_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_11
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_11_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 11 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 11: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_11.yaml
+++ b/components/wavinahc9000v2/configs/channel_11.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_11
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_11_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_11_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_11_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_11}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 11 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 11: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_11_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_11_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_12.yaml
+++ b/components/wavinahc9000v2/configs/channel_12.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_12_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_12
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_12_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 12 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 12: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_12.yaml
+++ b/components/wavinahc9000v2/configs/channel_12.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_12
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_12_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_12_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_12_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_12}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 12 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 12: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_12_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_12_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_13.yaml
+++ b/components/wavinahc9000v2/configs/channel_13.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_13
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_13_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_13.yaml
+++ b/components/wavinahc9000v2/configs/channel_13.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_13_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_13
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_13_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 13 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 13: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_13_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_13_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_13_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_13_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_13}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 13 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 13: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_14.yaml
+++ b/components/wavinahc9000v2/configs/channel_14.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_14_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_14
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_14_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 14 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 14: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_14.yaml
+++ b/components/wavinahc9000v2/configs/channel_14.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_14
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_14_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_14_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_14_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_14}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 14 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 14: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_14_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_14_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_15.yaml
+++ b/components/wavinahc9000v2/configs/channel_15.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_15_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_15
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_15_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 15 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 15: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_15.yaml
+++ b/components/wavinahc9000v2/configs/channel_15.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_15
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_15_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_15_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_15_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_15}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 15 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 15: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_15_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_15_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_16.yaml
+++ b/components/wavinahc9000v2/configs/channel_16.yaml
@@ -17,12 +17,17 @@ sensor:
     device_class: temperature
     force_update: True
     lambda: |-
-      for (int i = 0; i < data.size(); i++) {
-        ESP_LOGD("DEBUG", "data[%d] = 0x%02X", i, data[i]);
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
+        return {};
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Correct raw_temp assembled: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 # ----------- Battery ----------- #
   - platform:               modbus_controller
     name:                   ${name} Battery ${channel_16_friendly_name}
@@ -40,9 +45,10 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Battery raw value: %d", raw_battery);
-      return raw_battery * 10.0;
+      if (raw_battery > 100) return {};
+      return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
   - platform:               modbus_controller
@@ -57,8 +63,8 @@ binary_sensor:
       - $channel_16
       - 0x01
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t value = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Output status raw value: 0x%04X", value);
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_16_friendly_name}: %s", heating ? "ON" : "OFF");
       return heating;
@@ -90,9 +96,11 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t raw_temp = (data[2] << 8) | data[3];
-      ESP_LOGD("DEBUG", "Target temp raw value: %d", raw_temp);
-      return raw_temp * 0.1;
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 # ----------- Switch ----------- #
 switch:
   - platform:               modbus_controller
@@ -108,7 +116,6 @@ switch:
       - 0x01
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 16 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -132,8 +139,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 16: 0x%04X",mode);    
+      if (data.size() < 4) return {};
+      uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_16.yaml
+++ b/components/wavinahc9000v2/configs/channel_16.yaml
@@ -19,13 +19,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Temperature response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Temperature out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 # ----------- Battery ----------- #
@@ -45,9 +45,9 @@ sensor:
     accuracy_decimals: 1
     device_class: battery
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_battery = (data[2] << 8) | data[3];
-      if (raw_battery > 100) return {};
+      if (raw_battery > 100) return NAN;
       return raw_battery * 10.0f;
 # ----------- Binary ----------- #
 binary_sensor:
@@ -63,7 +63,7 @@ binary_sensor:
       - $channel_16
       - 0x01
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t value = (data[2] << 8) | data[3];
       bool heating = (value & 0x0010) != 0;
       ESP_LOGD("DEBUG", "Heating output for channel ${channel_16_friendly_name}: %s", heating ? "ON" : "OFF");
@@ -96,10 +96,10 @@ number:
       payload.push_back(targettemp);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return NAN;
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 # ----------- Switch ----------- #
 switch:
@@ -139,7 +139,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];    
       return (mode & 0x01) != 0;
 

--- a/components/wavinahc9000v2/configs/channel_16_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_16_comfort.yaml
@@ -15,8 +15,18 @@ sensor:
     unit_of_measurement: "°C"
     accuracy_decimals: 1
     device_class: temperature
-    filters:
-      - multiply: 0.1
+    lambda: |-
+      if (data.size() < 4) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
+        return {};
+      }
+      uint16_t raw_temp = (data[2] << 8) | data[3];
+      float temp_c = raw_temp * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) {
+        ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
+        return {};
+      }
+      return temp_c;
 
 # ----------- Number ----------- #
 number:
@@ -45,7 +55,10 @@ number:
       payload.push_back(${channel_16}01);
       payload.push_back(targettemp);
       return true;
-    lambda: "return x*0.1;"
+    lambda: |-
+      float temp_c = x * 0.1f;
+      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      return temp_c;
 
 # ----------- Switch ----------- #
 switch:
@@ -62,7 +75,6 @@ switch:
       - 0x03
     write_lambda: |-
       ESP_LOGD("main","Modbus Switch incoming state for channel 16 = %s",ONOFF(x));
-      bool state = ONOFF(x);
       uint8_t MODE_MASK = 0x07;
       payload.push_back(0x01);
       payload.push_back(0x45);
@@ -86,8 +98,8 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
+      if (data.size() < 4) return {};
       uint16_t mode = (data[2] << 8) | data[3];
-      ESP_LOGD("main","MODE raw value for Channel 16: 0x%04X",mode);
       return (mode & 0x01) != 0;
 
 # ----------- Climate ----------- #

--- a/components/wavinahc9000v2/configs/channel_16_comfort.yaml
+++ b/components/wavinahc9000v2/configs/channel_16_comfort.yaml
@@ -18,13 +18,13 @@ sensor:
     lambda: |-
       if (data.size() < 4) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp response too short (%d bytes)", data.size());
-        return {};
+        return NAN;
       }
       uint16_t raw_temp = (data[2] << 8) | data[3];
       float temp_c = raw_temp * 0.1f;
       if (temp_c < 1.0f || temp_c > 90.0f) {
         ESP_LOGW("wavinahc9000v2", "Comfort temp out of range: %.1f C (raw=%d), ignoring", temp_c, raw_temp);
-        return {};
+        return NAN;
       }
       return temp_c;
 
@@ -57,7 +57,7 @@ number:
       return true;
     lambda: |-
       float temp_c = x * 0.1f;
-      if (temp_c < 1.0f || temp_c > 90.0f) return {};
+      if (temp_c < 1.0f || temp_c > 90.0f) return NAN;
       return temp_c;
 
 # ----------- Switch ----------- #
@@ -98,7 +98,7 @@ switch:
       payload.push_back((~MODE_MASK) & 0xFF);
       return true;
     lambda: |-
-      if (data.size() < 4) return {};
+      if (data.size() < 4) return false;
       uint16_t mode = (data[2] << 8) | data[3];
       return (mode & 0x01) != 0;
 


### PR DESCRIPTION
## Summary

This PR fixes multiple issues in the `wavinahc9000v2` component:

### Bugs Fixed

1. **Temperature randomly drops to 0.4°C** — Raw modbus responses were published without validation. Added plausibility filtering (1.0–90.0°C range) with `data.size()` checks to all sensor/number/binary_sensor/switch lambdas across all 32 channel config files.

2. **Lambda `return {}` leaks raw U_WORD decode** — ESPHome's `modbus_controller` `parse_and_publish()` always publishes even when a lambda returns `{}` (empty optional). The raw `payload_to_float()` U_WORD decode was leaking through, causing channels with no thermostat to show 17154.0°C (0x4302 = response frame header bytes). Fixed by returning `NAN` for float lambdas and `false` for bool lambdas.

3. **`bool state = ONOFF(x)` compiler warning** — `ONOFF()` returns `const char*`, not `bool`. The unused variable was removed from all 32 switch write_lambdas.

4. **`internal: true` misplaced** in `channel_01_comfort.yaml` — Was nested inside `custom_command` list instead of being a top-level number property.

5. **Python `yield` deprecation** — Both `__init__.py` files used generator-style `def to_code` with `yield`. Changed to `async def to_code` with `await`.

6. **C++ warnings** — Fixed `const char *TAG` → `const char *const TAG`, redundant `else if (!state)` → `else`, and deprecated `ClimateTraits` methods (`set_supports_action`/`set_supports_current_temperature` → `add_feature_flags()`).

### Updated

- `basic.yaml` now references `heinekmadsen/esphome_components@main`

### Testing

- Compiled with zero C++ warnings
- OTA deployed and verified with 120-second runtime log captures
- Active channels (with thermostats): correct temperature readings
- Inactive channels (no thermostat): correctly show NAN/unavailable instead of bogus values
- Zero modbus errors/timeouts