### PR TITLE
ESPHome 2026.5.1 compatibility fixes

### DIFF
--- a/components/balboa_spa/climate/balboa_climate.h
+++ b/components/balboa_spa/climate/balboa_climate.h
@@ -17,10 +17,10 @@ namespace esphome
       climate::ClimateTraits traits() override
       {
         auto traits = climate::ClimateTraits();
-        traits.set_supports_action(true);
+        traits.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
         traits.add_supported_mode(climate::CLIMATE_MODE_HEAT);
         traits.add_supported_mode(climate::CLIMATE_MODE_OFF);
-        traits.set_supports_current_temperature(true);
+        traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
         traits.set_visual_min_temperature(26.0);
         traits.set_visual_max_temperature(40.0);
         traits.set_visual_temperature_step(0.5);

--- a/components/genvexv2/climate/genvexv2_climate.cpp
+++ b/components/genvexv2/climate/genvexv2_climate.cpp
@@ -7,6 +7,8 @@ namespace genvexv2 {
 static const char *TAG = "genvexv2.climate";
 
 void Genvexv2Climate::setup() {
+  this->set_supported_custom_fan_modes({"1", "2", "3", "4"});
+
   current_temp_sensor_->add_on_state_callback([this](float state) {
     ESP_LOGD(TAG, "CURRENT TEMP SENSOR CALLBACK: %f", state);
     current_temperature = state;
@@ -104,13 +106,6 @@ void Genvexv2Climate::control(const climate::ClimateCall& call) {
 
 climate::ClimateTraits Genvexv2Climate::traits() {
   auto traits = climate::ClimateTraits();
-
-  traits.set_supported_custom_fan_modes({
-    "1",
-    "2",
-    "3",
-    "4"
-  });
 
   traits.set_supported_fan_modes({ 
     climate::ClimateFanMode::CLIMATE_FAN_OFF 

--- a/components/genvexv2/climate/genvexv2_climate.cpp
+++ b/components/genvexv2/climate/genvexv2_climate.cpp
@@ -143,42 +143,24 @@ void Genvexv2Climate::apply_custom_fan_mode_string_(const std::string &mode_text
   }
 }
 
-void Genvexv2Climate::genvexv2fanspeed_to_fanmode(const int state)
+void Genvexv2Climate::genvexv2fanspeed_to_fanmode(float state)
 {
-  ESP_LOGD("TAG", "In genvexv2fanspeed_to_fanmode");
-  ESP_LOGD("TAG", "State is %i", state);
+  const int istate = static_cast<int>(state);
+  ESP_LOGD(TAG, "In genvexv2fanspeed_to_fanmode, state=%i", istate);
   this->clear_custom_fan_mode_();
   this->fan_mode.reset();
 
-  switch (state) {
+  switch (istate) {
   case 1:
-    ESP_LOGD("TAG", "Case 1");
-    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-    this->apply_custom_fan_mode_string_(esphome::to_string(state));
-    break;
   case 2:
-    ESP_LOGD("TAG", "Case 2");
-    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-    this->apply_custom_fan_mode_string_(esphome::to_string(state));
-    break;
   case 3:
-    ESP_LOGD("TAG", "Case 3");
-    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-    this->apply_custom_fan_mode_string_(esphome::to_string(state));
-    break;
   case 4:
-    ESP_LOGD("TAG", "Case 4");
     this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-    this->apply_custom_fan_mode_string_(esphome::to_string(state));
+    this->apply_custom_fan_mode_string_(esphome::to_string(istate));
     break;
   case 0:
-    ESP_LOGD("TAG", "Case 0");
-    this->fan_mode = climate::CLIMATE_FAN_OFF; 
-    this->mode = climate::CLIMATE_MODE_OFF;
-    break;
-  default: 
-    ESP_LOGD("TAG", "Case default");
-    this->fan_mode = climate::CLIMATE_FAN_OFF; 
+  default:
+    this->fan_mode = climate::CLIMATE_FAN_OFF;
     this->mode = climate::CLIMATE_MODE_OFF;
     break;
   }

--- a/components/genvexv2/climate/genvexv2_climate.h
+++ b/components/genvexv2/climate/genvexv2_climate.h
@@ -53,9 +53,7 @@ protected:
 
 private:
 
-  void genvexv2fanspeed_to_fanmode(const int state);
-  int climatemode_to_genvexv2operationmode(const climate::ClimateMode mode);
-  void genvexv2modetext_to_climatemode(const std::string& genvexv2_mode);
+  void genvexv2fanspeed_to_fanmode(float state);
   void apply_custom_fan_mode_string_(const std::string &mode_text);
 };
 } // namespace genvexv2

--- a/components/genvexv2/genvexv2.h
+++ b/components/genvexv2/genvexv2.h
@@ -9,5 +9,5 @@ class Genvexv2 : public Component {
   public:
     Genvexv2() {}
 };
-} // namespace genvex
+} // namespace genvexv2
 } // namespace esphome

--- a/components/genvexv2/optima250-develop.yaml
+++ b/components/genvexv2/optima250-develop.yaml
@@ -2,7 +2,8 @@ external_components:
   - source: 
       type: git
       url: https://github.com/heinekmadsen/esphome_components
-      ref: "develop"
+      #ref: "develop"
+      ref: "fix/genvexv2-compile-warnings"
     refresh: 0s
     components: [genvexv2]
 

--- a/components/genvexv2/optima250-develop.yaml
+++ b/components/genvexv2/optima250-develop.yaml
@@ -2,8 +2,8 @@ external_components:
   - source: 
       type: git
       url: https://github.com/heinekmadsen/esphome_components
-      #ref: "develop"
-      ref: "fix/genvexv2-compile-warnings"
+      ref: "develop"
+      #ref: "fix/genvexv2-compile-warnings"
     refresh: 0s
     components: [genvexv2]
 

--- a/components/genvexv2/select/__init__.py
+++ b/components/genvexv2/select/__init__.py
@@ -38,7 +38,6 @@ CONFIG_SCHEMA = select.select_schema(Genvexv2Select).extend({
     #cv.Optional(CONF_REGISTER_COUNT, default=0): cv.positive_int,
     cv.Optional(CONF_SKIP_UPDATES, default=0): cv.positive_int,
     cv.Optional(CONF_FORCE_NEW_RANGE, default=False): cv.boolean,
-    cv.Optional(CONF_FORCE_NEW_RANGE, default=False): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
  
 def to_code(config):

--- a/components/genvexv2/select/genvexv2_select.cpp
+++ b/components/genvexv2/select/genvexv2_select.cpp
@@ -30,10 +30,8 @@ void Genvexv2Select::control(const std::string &value) {
 
   for (size_t i = 0; i < options.size(); ++i) {
     if (value == options[i]) {
-      ESP_LOGD(TAG, "WRITING INDEX: %d", i);
-      std::vector<uint16_t> data = modbus_controller::float_to_payload(i, modbus_controller::SensorValueType::U_WORD);
-      uint16_t speed = i;
-      ESP_LOGD(TAG, "UINT16_t speed: %i", speed);
+      uint16_t speed = static_cast<uint16_t>(i);
+      ESP_LOGD(TAG, "WRITING INDEX: %d (speed: %u)", i, speed);
       //auto write_cmd = ModbusCommandItem::create_write_multiple_command(modbus_controller_, this->start_address + this->offset, this->register_count, data);
       auto write_cmd = ModbusCommandItem::create_write_single_command(modbus_controller_, this->start_address, speed);
 

--- a/components/genvexv2/select/genvexv2_select.cpp
+++ b/components/genvexv2/select/genvexv2_select.cpp
@@ -10,11 +10,6 @@ using modbus_controller::ModbusCommandItem;
 using modbus_controller::ModbusRegisterType;
 
 void Genvexv2Select::parse_and_publish(const std::vector<uint8_t> &data) {
-  union {
-    float float_value;
-    uint32_t raw;
-  } raw_to_float;
-
   float received_value = payload_to_float(data, *this);
   ESP_LOGD(TAG, "Genvexv2 Select index: %f", received_value);
 
@@ -22,9 +17,9 @@ void Genvexv2Select::parse_and_publish(const std::vector<uint8_t> &data) {
 
   if (received_value >= 0 && received_value < options.size()) {
     const auto index = static_cast<size_t>(received_value);
-    const char *select_value = options[index];
-    ESP_LOGD(TAG, "Select new state : %s", select_value);
-    this->publish_state(std::string(select_value));
+    const std::string &select_value = options[index];
+    ESP_LOGD(TAG, "Select new state : %s", select_value.c_str());
+    this->publish_state(select_value);
   }
 }
 

--- a/components/sentio/__init__.py
+++ b/components/sentio/__init__.py
@@ -11,6 +11,6 @@ CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(Sentio),   
 })
 
-def to_code(config):
+async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    yield cg.register_component(var, config) 
+    await cg.register_component(var, config)

--- a/components/sentio/climate/__init__.py
+++ b/components/sentio/climate/__init__.py
@@ -21,16 +21,16 @@ CONFIG_SCHEMA = climate.climate_schema(SentioClimate).extend({
     cv.Required(CONF_MODE): cv.use_id(sensor.Sensor)
 }).extend(cv.COMPONENT_SCHEMA)
  
-def to_code(config):
+async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    yield cg.register_component(var, config)
-    yield climate.register_climate(var, config)
+    await cg.register_component(var, config)
+    await climate.register_climate(var, config)
 
-    number_set_temp = yield cg.get_variable(config[CONF_TARGET_TEMP])
+    number_set_temp = await cg.get_variable(config[CONF_TARGET_TEMP])
     cg.add(var.set_temp_setpoint_number(number_set_temp))
 
-    sens_current_temp = yield cg.get_variable(config[CONF_CURRENT_TEMP])
+    sens_current_temp = await cg.get_variable(config[CONF_CURRENT_TEMP])
     cg.add(var.current_temp_sensor(sens_current_temp))
 
-    read_mode = yield cg.get_variable(config[CONF_MODE])
+    read_mode = await cg.get_variable(config[CONF_MODE])
     cg.add(var.mode_select(read_mode))

--- a/components/sentio/climate/sentio_climate.cpp
+++ b/components/sentio/climate/sentio_climate.cpp
@@ -43,7 +43,7 @@ void SentioClimate::control(const climate::ClimateCall& call) {
 climate::ClimateTraits SentioClimate::traits() {
   auto traits = climate::ClimateTraits();
 
-  traits.set_supports_current_temperature(true);
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
   traits.set_visual_temperature_step(0.1);
   traits.set_visual_min_temperature(5);
   traits.set_visual_max_temperature(30);

--- a/components/sentio/configs/basic.yaml
+++ b/components/sentio/configs/basic.yaml
@@ -1,5 +1,5 @@
 external_components:
-  - source: github://heinekmadsen/esphome_components
+  - source: github://heinekmadsen/esphome_components@esphomefix
     refresh: 0s  
     
 sentio:

--- a/components/wavinahc9000v2/configs/basic.yaml
+++ b/components/wavinahc9000v2/configs/basic.yaml
@@ -2,7 +2,7 @@ external_components:
   - source: 
       type: git
       url: https://github.com/heinekmadsen/esphome_components
-      ref: main
+      ref: esphomefix
     refresh: 0s
     components: [wavinahc9000v2]
 


### PR DESCRIPTION
Fixes breaking changes in ESPHome 2026.5.1:

- **Sentio component**: Converted yield-based coroutines to async/await in Python codegen
- **Sentio climate**: Replaced removed set_supports_current_temperature() with add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE)
- Updated config refs

All three configs (sentio, v2, v3) compile successfully on ESPHome 2026.5.1.