### PR TITLE
Add missing Genvex modbus controller sensors for configurations for inlet/outlet speed modes and bypass temperature settings

### DIFF
--- a/components/genvexv2/optima250-develop.yaml
+++ b/components/genvexv2/optima250-develop.yaml
@@ -357,7 +357,117 @@ number:
     step: 1.0
     address: 100
 
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 1 Inlet Speed"
+    id: genvex_step1_inlet_speed
+    icon: mdi:fan-speed-1
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 6
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 2 Inlet Speed"
+    id: genvex_step2_inlet_speed
+    icon: mdi:fan-speed-2
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 7
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 3 Inlet Speed"
+    id: genvex_step3_inlet_speed
+    icon: mdi:fan-speed-3
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 8
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 1 Outlet Speed"
+    id: genvex_step1_outlet_speed
+    icon: mdi:fan-speed-1
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 9
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 2 Outlet Speed"
+    id: genvex_step2_outlet_speed
+    icon: mdi:fan-speed-2
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 10
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 3 Outlet Speed"
+    id: genvex_step3_outlet_speed
+    icon: mdi:fan-speed-3
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 11
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Bypass Open Max Temp"
+    id: genvex_bypass_open_max_temp
+    icon: mdi:thermometer
+    unit_of_measurement: °C
+    min_value: 1
+    max_value: 10
+    register_type: holding
+    value_type: U_WORD
+    address: 17
+    step: 0.1
+    lambda: "return x/10;"
+    write_lambda: |-
+      ESP_LOGD("Genvex target temp","Processing new bypass max open temp %d", x);
+      uint16_t new_temp = (x * 100)/10;
+      ESP_LOGD("Genvex target temp","New value %d", new_temp);
+      return new_temp;
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Bypass Close on Low Inlet Temp (Diff From Target Temp)"
+    id: bypass_close_on_low_inlet_temp
+    icon: mdi:thermometer
+    unit_of_measurement: °C
+    min_value: 0
+    max_value: 20
+    register_type: holding
+    value_type: U_WORD
+    address: 25
+
 binary_sensor:
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex On/Off Possible On K1"
+    id: genvex_on_off_possible
+    register_type: holding
+    address: 24
+
   - platform: modbus_controller
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex bypass onoff"

--- a/components/genvexv2/optima250-develop.yaml
+++ b/components/genvexv2/optima250-develop.yaml
@@ -450,8 +450,8 @@ number:
 
   - platform: modbus_controller
     modbus_controller_id: genvex_modbus_controller
-    name: "Bypass Close on Low Inlet Temp (Diff From Target Temp)"
-    id: bypass_close_on_low_inlet_temp
+    name: "Genvex Bypass Close on Low Inlet Temp (Diff From Target Temp)"
+    id: genvex_bypass_close_on_low_inlet_temp
     icon: mdi:thermometer
     unit_of_measurement: °C
     min_value: 0

--- a/components/genvexv2/optima250-develop.yaml
+++ b/components/genvexv2/optima250-develop.yaml
@@ -444,7 +444,7 @@ number:
     lambda: "return x/10;"
     write_lambda: |-
       ESP_LOGD("Genvex bypass max temp","Processing new bypass max open temp %f", x);
-      uint16_t new_temp = x * 10;
+      uint16_t new_temp = lroundf(x * 10.0f);
       ESP_LOGD("Genvex bypass max temp","New value %d", new_temp);
       return new_temp;
 

--- a/components/genvexv2/optima250-develop.yaml
+++ b/components/genvexv2/optima250-develop.yaml
@@ -443,9 +443,9 @@ number:
     step: 0.1
     lambda: "return x/10;"
     write_lambda: |-
-      ESP_LOGD("Genvex target temp","Processing new bypass max open temp %d", x);
-      uint16_t new_temp = (x * 100)/10;
-      ESP_LOGD("Genvex target temp","New value %d", new_temp);
+      ESP_LOGD("Genvex bypass max temp","Processing new bypass max open temp %f", x);
+      uint16_t new_temp = x * 10;
+      ESP_LOGD("Genvex bypass max temp","New value %d", new_temp);
       return new_temp;
 
   - platform: modbus_controller

--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -356,7 +356,117 @@ number:
     step: 1.0
     address: 100
 
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 1 Inlet Speed"
+    id: genvex_step1_inlet_speed
+    icon: mdi:fan-speed-1
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 6
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 2 Inlet Speed"
+    id: genvex_step2_inlet_speed
+    icon: mdi:fan-speed-2
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 7
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 3 Inlet Speed"
+    id: genvex_step3_inlet_speed
+    icon: mdi:fan-speed-3
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 8
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 1 Outlet Speed"
+    id: genvex_step1_outlet_speed
+    icon: mdi:fan-speed-1
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 9
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 2 Outlet Speed"
+    id: genvex_step2_outlet_speed
+    icon: mdi:fan-speed-2
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 10
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Step 3 Outlet Speed"
+    id: genvex_step3_outlet_speed
+    icon: mdi:fan-speed-3
+    min_value: 0
+    max_value: 100
+    unit_of_measurement: '%'
+    register_type: holding
+    value_type: U_WORD
+    address: 11
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex Bypass Open Max Temp"
+    id: genvex_bypass_open_max_temp
+    icon: mdi:thermometer
+    unit_of_measurement: °C
+    min_value: 1
+    max_value: 10
+    register_type: holding
+    value_type: U_WORD
+    address: 17
+    step: 0.1
+    lambda: "return x/10;"
+    write_lambda: |-
+      ESP_LOGD("Genvex target temp","Processing new bypass max open temp %d", x);
+      uint16_t new_temp = (x * 100)/10;
+      ESP_LOGD("Genvex target temp","New value %d", new_temp);
+      return new_temp;
+
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Bypass Close on Low Inlet Temp (Diff From Target Temp)"
+    id: bypass_close_on_low_inlet_temp
+    icon: mdi:thermometer
+    unit_of_measurement: °C
+    min_value: 0
+    max_value: 20
+    register_type: holding
+    value_type: U_WORD
+    address: 25
+
 binary_sensor:
+  - platform: modbus_controller
+    modbus_controller_id: genvex_modbus_controller
+    name: "Genvex On/Off Possible On K1"
+    id: genvex_on_off_possible
+    register_type: holding
+    address: 24
+
   - platform: modbus_controller
     modbus_controller_id: genvex_modbus_controller
     name: "Genvex bypass onoff"

--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -443,7 +443,7 @@ number:
     lambda: "return x/10;"
     write_lambda: |-
       ESP_LOGD("Genvex bypass max temp","Processing new bypass max open temp %f", x);
-      uint16_t new_temp = x * 10;
+      uint16_t new_temp = lroundf(x * 10.0f);
       ESP_LOGD("Genvex bypass max temp","New value %d", new_temp);
       return new_temp;
 

--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -442,9 +442,9 @@ number:
     step: 0.1
     lambda: "return x/10;"
     write_lambda: |-
-      ESP_LOGD("Genvex target temp","Processing new bypass max open temp %d", x);
-      uint16_t new_temp = (x * 100)/10;
-      ESP_LOGD("Genvex target temp","New value %d", new_temp);
+      ESP_LOGD("Genvex bypass max temp","Processing new bypass max open temp %f", x);
+      uint16_t new_temp = x * 10;
+      ESP_LOGD("Genvex bypass max temp","New value %d", new_temp);
       return new_temp;
 
   - platform: modbus_controller

--- a/components/genvexv2/optima250.yaml
+++ b/components/genvexv2/optima250.yaml
@@ -449,8 +449,8 @@ number:
 
   - platform: modbus_controller
     modbus_controller_id: genvex_modbus_controller
-    name: "Bypass Close on Low Inlet Temp (Diff From Target Temp)"
-    id: bypass_close_on_low_inlet_temp
+    name: "Genvex Bypass Close on Low Inlet Temp (Diff From Target Temp)"
+    id: genvex_bypass_close_on_low_inlet_temp
     icon: mdi:thermometer
     unit_of_measurement: °C
     min_value: 0

--- a/components/sentio/configs/basic.yaml
+++ b/components/sentio/configs/basic.yaml
@@ -1,5 +1,5 @@
 external_components:
-  - source: github://heinekmadsen/esphome_components@esphomefix
+  - source: github://heinekmadsen/esphome_components
     refresh: 0s  
     
 sentio:


### PR DESCRIPTION
Originally implemented by @lskov:
https://github.com/lskov/esphome_components