### PR TITLE
Update modbus imports for ESPHome 2026.5 compatibility

### DIFF
--- a/components/genvexv2/select/__init__.py
+++ b/components/genvexv2/select/__init__.py
@@ -3,14 +3,14 @@ import esphome.config_validation as cv
 from esphome.components import select, modbus_controller
 from .. import Genvexv2, CONF_GENVEXV2_ID
 
-from esphome.components.modbus_controller import (
+from esphome.components.modbus.helpers import SENSOR_VALUE_TYPE
+from esphome.components.modbus_controller.const import (
     CONF_MODBUS_CONTROLLER_ID,
     CONF_FORCE_NEW_RANGE,
     CONF_BYTE_OFFSET,
     CONF_SKIP_UPDATES,
     CONF_REGISTER_TYPE,
     CONF_VALUE_TYPE,
-    SENSOR_VALUE_TYPE,
 )
 
 from esphome.const import (

--- a/components/sentio/configs/basic.yaml
+++ b/components/sentio/configs/basic.yaml
@@ -1,5 +1,5 @@
 external_components:
-  - source: github://heinekmadsen/esphome_components@esphomefix
+  - source: github://heinekmadsen/esphome_components
     refresh: 0s  
     
 sentio:


### PR DESCRIPTION
**ESPHome 2026.5.0 refactored the `modbus_controller` module, moving `SENSOR_VALUE_TYPE` from `esphome.components.modbus_controller` into a new shared helpers module at `esphome.components.modbus.helpers`. The `CONF_*` constants were simultaneously moved to `esphome.components.modbus_controller.const`.**

**This caused an `ImportError` on startup when using ESPHome 2026.5.0:**
```
ImportError: cannot import name 'SENSOR_VALUE_TYPE' from 'esphome.components.modbus_controller'
```

**Fix:** Split the import in `genvexv2/select/__init__.py` so `SENSOR_VALUE_TYPE` is imported from `esphome.components.modbus.helpers` and the `CONF_*` constants are imported from `esphome.components.modbus_controller.const`, matching the import structure used in ESPHome's own built-in `modbus_controller` subcomponents.