### PR TITLE
Fix wavinAhc9000 for ESPHome 2026.x (climate feature flags + modbus core rewrite)

### DIFF
--- a/components/wavinAhc9000/__init__.py
+++ b/components/wavinAhc9000/__init__.py
@@ -17,6 +17,6 @@ CONFIG_SCHEMA = cv.Schema({
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await modbus.register_modbus_client_device(var, config)
+    await modbus.register_modbus_device(var, config)
     pin = await cg.gpio_pin_expression(config[CONF_RW_PIN])
     cg.add(var.set_rw_pin(pin))

--- a/components/wavinAhc9000/__init__.py
+++ b/components/wavinAhc9000/__init__.py
@@ -1,22 +1,33 @@
+import logging
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome import core, pins
+from esphome import pins
 from esphome.components import modbus
 from esphome.const import CONF_ID, CONF_RW_PIN
 
+_LOGGER = logging.getLogger(__name__)
+
 wavinAhc9000_ns = cg.esphome_ns.namespace('wavinAhc9000')
-WavinAhc9000 = wavinAhc9000_ns.class_('WavinAhc9000', cg.PollingComponent)
+WavinAhc9000 = wavinAhc9000_ns.class_('WavinAhc9000', cg.PollingComponent, modbus.ModbusClientDevice)
 
 CONF_WAVINAHC9000_ID = 'wavinAhc9000_id'
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(WavinAhc9000),
-    cv.Required(CONF_RW_PIN): pins.gpio_output_pin_schema
+    # Deprecated: RS-485 direction control is now handled by the modbus hub via
+    # `flow_control_pin`, because sends are queued/async and this component can no
+    # longer toggle the DE pin itself. Accepted but ignored for config compatibility.
+    cv.Optional(CONF_RW_PIN): pins.gpio_output_pin_schema,
 }).extend(cv.polling_component_schema('60s')).extend(modbus.modbus_device_schema(0x01))
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await modbus.register_modbus_device(var, config)
-    pin = await cg.gpio_pin_expression(config[CONF_RW_PIN])
-    cg.add(var.set_rw_pin(pin))
+    await modbus.register_modbus_client_device(var, config)
+    if CONF_RW_PIN in config:
+        _LOGGER.warning(
+            "wavinAhc9000: 'rw_pin' is deprecated and ignored. Move RS-485 direction "
+            "control to the modbus hub: 'modbus: { flow_control_pin: <pin> }'."
+        )

--- a/components/wavinAhc9000/__init__.py
+++ b/components/wavinAhc9000/__init__.py
@@ -17,6 +17,6 @@ CONFIG_SCHEMA = cv.Schema({
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await modbus.register_modbus_device(var, config)
+    await modbus.register_modbus_client_device(var, config)
     pin = await cg.gpio_pin_expression(config[CONF_RW_PIN])
     cg.add(var.set_rw_pin(pin))

--- a/components/wavinAhc9000/climate/wavinAhc9000_climate.cpp
+++ b/components/wavinAhc9000/climate/wavinAhc9000_climate.cpp
@@ -59,7 +59,7 @@ void WavinAhc9000Climate::control(const climate::ClimateCall &call) {
 
 climate::ClimateTraits WavinAhc9000Climate::traits() {
   auto traits = climate::ClimateTraits();
-  traits.set_supports_current_temperature(true);
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
   traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
   traits.set_visual_min_temperature(5.0);
   traits.set_visual_max_temperature(40.0);

--- a/components/wavinAhc9000/wavinAhc9000.cpp
+++ b/components/wavinAhc9000/wavinAhc9000.cpp
@@ -56,15 +56,15 @@ void WavinAhc9000::send_read_(uint8_t function_code, uint16_t arg1, uint16_t arg
   this->send_pdu(std::span<const uint8_t>(pdu, sizeof(pdu)));
 }
 
-void WavinAhc9000::on_response(std::span<const uint8_t> request_pdu, std::span<const uint8_t> response_pdu) {
+void WavinAhc9000::on_modbus_data(const std::vector<uint8_t> &data) {
   this->waiting_ = false;
-  // response_pdu is the PDU without address/CRC: [function_code][byte_count][payload...]
-  if (response_pdu.size() < 2) {
+  // The modbus core already stripped the address and the function code, so `data`
+  // is [byte_count][payload...]. Skip the byte-count byte to reach the payload.
+  if (data.size() < 2) {
     ESP_LOGW(TAG, "Invalid modbus response - too short");
     return;
   }
-  // Skip function code + byte count to reach the payload, matching the original parser.
-  std::vector<uint8_t> payload(response_pdu.begin() + 2, response_pdu.end());
+  std::vector<uint8_t> payload(data.begin() + 1, data.end());
 
   float temperature;
   switch (state_) {
@@ -88,7 +88,7 @@ void WavinAhc9000::on_response(std::span<const uint8_t> request_pdu, std::span<c
   }
 }
 
-bool WavinAhc9000::on_no_response() {
+bool WavinAhc9000::on_modbus_no_response() {
   this->waiting_ = false;
   if (state_ == 0) {
     ESP_LOGD(TAG, "Timeout on set temperature on channel %d", channel_ + 1);
@@ -138,7 +138,7 @@ void WavinAhc9000::handle_mode_data_(const std::vector<uint8_t> &data) {
 }
 
 void WavinAhc9000::loop() {
-  // One transaction in flight at a time; on_response()/on_no_response() clear this.
+  // One transaction in flight at a time; on_modbus_data()/on_modbus_no_response() clear this.
   if (this->waiting_)
     return;
 

--- a/components/wavinAhc9000/wavinAhc9000.cpp
+++ b/components/wavinAhc9000/wavinAhc9000.cpp
@@ -23,11 +23,6 @@ static const uint8_t ALL_TP_LOST_MASK = 0x02;
 static const uint8_t CHANNEL_OUTP_ON = 0x10;
 static const uint8_t MODE_MASK = 0x07;
 
-void WavinAhc9000::setup() {
-  rw_pin_->setup();
-  rw_pin_->digital_write(false);
-}
-
 void WavinAhc9000::add_temp_callback(int channel, std::function<void(float)> &&callback) {
   temp_callbacks_[channel].add(std::move(callback));
 }
@@ -53,19 +48,24 @@ void WavinAhc9000::set_target_temp(int channel, float temperature) {
   temp_channel_.push_back(channel);
 }
 
-void WavinAhc9000::on_modbus_data(const std::vector<uint8_t> &data) {
-  ESP_LOGV(TAG, "Channel %d, state %d, Data: %s", channel_ + 1, state_, format_hex_pretty(data).c_str());
-  
-  // Modbus response format: [function_code][byte_count][payload...]
-  // For function 0x43/0x44, skip first 2 bytes to get actual data payload
-  if (data.size() < 2) {
+void WavinAhc9000::send_read_(uint8_t function_code, uint16_t arg1, uint16_t arg2) {
+  // Wavin custom read: [function][arg1 hi][arg1 lo][arg2 hi][arg2 lo].
+  // send_pdu() prepends the device address and appends the CRC.
+  const uint8_t pdu[5] = {function_code, (uint8_t) (arg1 >> 8), (uint8_t) (arg1 & 0xff),
+                         (uint8_t) (arg2 >> 8), (uint8_t) (arg2 & 0xff)};
+  this->send_pdu(std::span<const uint8_t>(pdu, sizeof(pdu)));
+}
+
+void WavinAhc9000::on_response(std::span<const uint8_t> request_pdu, std::span<const uint8_t> response_pdu) {
+  this->waiting_ = false;
+  // response_pdu is the PDU without address/CRC: [function_code][byte_count][payload...]
+  if (response_pdu.size() < 2) {
     ESP_LOGW(TAG, "Invalid modbus response - too short");
-    waiting_ = false;
     return;
   }
-  
-  std::vector<uint8_t> payload(data.begin() + 2, data.end());
-  
+  // Skip function code + byte count to reach the payload, matching the original parser.
+  std::vector<uint8_t> payload(response_pdu.begin() + 2, response_pdu.end());
+
   float temperature;
   switch (state_) {
     case 0:
@@ -86,7 +86,18 @@ void WavinAhc9000::on_modbus_data(const std::vector<uint8_t> &data) {
       handle_mode_data_(payload);
       break;
   }
-  waiting_ = false;
+}
+
+bool WavinAhc9000::on_no_response() {
+  this->waiting_ = false;
+  if (state_ == 0) {
+    ESP_LOGD(TAG, "Timeout on set temperature on channel %d", channel_ + 1);
+    channel_ = -1;
+  } else {
+    ESP_LOGD(TAG, "Timeout on channel %d, state %d", channel_ + 1, state_);
+    state_ = 4;  // skip remaining reads for this channel
+  }
+  return false;  // do not ask the hub to retry
 }
 
 void WavinAhc9000::handle_channel_data_(const std::vector<uint8_t> &data) {
@@ -126,39 +137,10 @@ void WavinAhc9000::handle_mode_data_(const std::vector<uint8_t> &data) {
   mode_callbacks_[channel_].call(mode);
 }
 
-uint16_t crc16(const uint8_t *data, uint8_t len) {
-  uint16_t crc = 0xFFFF;
-  while (len--) {
-    crc ^= *data++;
-    for (uint8_t i = 0; i < 8; i++) {
-      if ((crc & 0x01) != 0) {
-        crc >>= 1;
-        crc ^= 0xA001;
-      } else {
-        crc >>= 1;
-      }
-    }
-  }
-  return crc;
-}
-
 void WavinAhc9000::loop() {
-  static uint32_t last_update_time = 0;
-  uint32_t now = millis();
-  if (waiting_) {
-    if (last_update_time + 1000 < now) {
-      if (state_ == 0) {
-        ESP_LOGD(TAG, "Timeout on set temperature on channel %d", channel_ + 1);
-        channel_ = -1;
-      } else {
-        ESP_LOGD(TAG, "Timeout on channel %d, state %d", channel_ + 1, state_);
-        state_ = 4;
-      }
-      waiting_ = false;
-    } else {
-      return;
-    }
-  }
+  // One transaction in flight at a time; on_response()/on_no_response() clear this.
+  if (this->waiting_)
+    return;
 
   if (set_temp_.size() && (channel_ < 0)) {
     int temperature = ((roundf(set_temp_.front() * 2.0) / 2) * 10);
@@ -167,18 +149,11 @@ void WavinAhc9000::loop() {
     channel_ = temp_channel_.front();
     temp_channel_.erase(temp_channel_.begin());
     ESP_LOGV(TAG, "Setting temperature for channel %d: %d", channel_ + 1, temperature);
-    uint8_t data[10] = {address_, MODBUS_WRITE_REGISTER, CATEGORY_PACKED_DATA, PACKED_DATA_MANUAL_TEMPERATURE,
-                        (uint8_t)channel_, 1, (uint8_t)(temperature >> 8), (uint8_t)(temperature & 0xff), 0, 0};
-    uint16_t crc = crc16(data, 8);
-    data[8] = crc & 0xff;
-    data[9] = crc >> 8;
-    rw_pin_->digital_write(true);
-    parent_->write_array(data, sizeof(data));
-    parent_->flush();
-    delay(1);
-    rw_pin_->digital_write(false);
-    waiting_ = true;
-    last_update_time = now;
+    // Wavin custom write: [function][category][index][channel][count=1][value hi][value lo].
+    const uint8_t pdu[7] = {MODBUS_WRITE_REGISTER, CATEGORY_PACKED_DATA, PACKED_DATA_MANUAL_TEMPERATURE,
+                           (uint8_t) channel_, 1, (uint8_t) (temperature >> 8), (uint8_t) (temperature & 0xff)};
+    this->send_pdu(std::span<const uint8_t>(pdu, sizeof(pdu)));
+    this->waiting_ = true;
     return;
   }
 
@@ -201,7 +176,7 @@ void WavinAhc9000::loop() {
     do {
       channel_++;
     } while (channel_ < 16 && !used_channels_[channel_]);
-    
+
     if (channel_ >= 16) {
       state_ = 0;
       channel_ = -1;
@@ -210,51 +185,28 @@ void WavinAhc9000::loop() {
     state_ = 1;
   }
 
-  rw_pin_->digital_write(true);
   ESP_LOGV(TAG, "Sending for channel %d, state %d", channel_ + 1, state_);
   switch(state_) {
     case 1:
-      send(MODBUS_READ_REGISTER, (CATEGORY_CHANNELS << 8) + 0, (channel_ << 8) + 3);
+      send_read_(MODBUS_READ_REGISTER, (CATEGORY_CHANNELS << 8) + 0, (channel_ << 8) + 3);
       break;
     case 2:
       ESP_LOGV(TAG, "Reading data for element %d", element_);
-      send(MODBUS_READ_REGISTER, (CATEGORY_ELEMENTS << 8) + 4, (element_ << 8) + 7);
+      send_read_(MODBUS_READ_REGISTER, (CATEGORY_ELEMENTS << 8) + 4, (element_ << 8) + 7);
       break;
     case 3:
-      send(MODBUS_READ_REGISTER, (CATEGORY_PACKED_DATA << 8) + PACKED_DATA_MANUAL_TEMPERATURE, (channel_ << 8) + 1);
+      send_read_(MODBUS_READ_REGISTER, (CATEGORY_PACKED_DATA << 8) + PACKED_DATA_MANUAL_TEMPERATURE, (channel_ << 8) + 1);
       break;
     case 4:
-      send(MODBUS_READ_REGISTER, (CATEGORY_PACKED_DATA << 8) + PACKED_DATA_CONFIGURATION, (channel_ << 8) + 1);
+      send_read_(MODBUS_READ_REGISTER, (CATEGORY_PACKED_DATA << 8) + PACKED_DATA_CONFIGURATION, (channel_ << 8) + 1);
       break;
   }
-  parent_->flush();
-  delay(1);
-  rw_pin_->digital_write(false);
-  waiting_ = true;
-  last_update_time = now;
+  this->waiting_ = true;
 }
 
 void WavinAhc9000::update() {
   start_scan_ = true;
 }
-
-/*
-// ------------------------------------------------
-// Functions for writing to Wavin AHC 9000
-void WavinAhc9000::writeFanMode_(int new_fan_speed)
-{
-	
-	//ESP_LOGD(TAG, "Writing new fan speed to system.... (%i)",new_fan_speed);
-	//this->send(CMD_WRITE_SINGLE_REG, 100, new_fan_speed);
-}
-
-void WavinAhc9000::writeTargetTemperature_(float new_target_temp)
-{
-	
-	//ESP_LOGD(TAG, "Writing new fan speed to system.... (%i)",new_fan_speed);
-	//this->send(CMD_WRITE_SINGLE_REG, 100, new_fan_speed);
-}
-*/
 
 } // wavinAhc9000
 } // esphome

--- a/components/wavinAhc9000/wavinAhc9000.h
+++ b/components/wavinAhc9000/wavinAhc9000.h
@@ -14,10 +14,10 @@ class WavinAhc9000 : public PollingComponent, public modbus::ModbusClientDevice 
     void update() override;
     void loop() override;
 
-    // New modbus client hooks (replace the old on_modbus_data path).
-    void on_response(std::span<const uint8_t> request_pdu, std::span<const uint8_t> response_pdu) override;
-    bool on_no_response() override;
-    void on_not_sent() override { this->waiting_ = false; }
+    // Modbus client-device hooks (ESPHome 2026.7.x API).
+    void on_modbus_data(const std::vector<uint8_t> &data) override;
+    bool on_modbus_no_response() override;
+    void on_modbus_not_sent() override { this->waiting_ = false; }
 
     void register_channel(int channel) { used_channels_[channel] = true; }
     void add_temp_callback(int channel, std::function<void(float)> &&callback);

--- a/components/wavinAhc9000/wavinAhc9000.h
+++ b/components/wavinAhc9000/wavinAhc9000.h
@@ -3,17 +3,22 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/modbus/modbus.h"
 
+#include <span>
+#include <vector>
+
 namespace esphome {
 namespace wavinAhc9000 {
 
-class WavinAhc9000 : public PollingComponent, public modbus::ModbusDevice {
+class WavinAhc9000 : public PollingComponent, public modbus::ModbusClientDevice {
   public:
-    void setup();
     void update() override;
     void loop() override;
-    void on_modbus_data(const std::vector<uint8_t> &data) override;
 
-    void set_rw_pin(GPIOPin *pin) { rw_pin_ = pin; }
+    // New modbus client hooks (replace the old on_modbus_data path).
+    void on_response(std::span<const uint8_t> request_pdu, std::span<const uint8_t> response_pdu) override;
+    bool on_no_response() override;
+    void on_not_sent() override { this->waiting_ = false; }
+
     void register_channel(int channel) { used_channels_[channel] = true; }
     void add_temp_callback(int channel, std::function<void(float)> &&callback);
     void add_bat_level_callback(int channel, std::function<void(float)> &&callback);
@@ -27,8 +32,9 @@ class WavinAhc9000 : public PollingComponent, public modbus::ModbusDevice {
     void handle_element_data_(const std::vector<uint8_t> &data);
     void handle_target_temp_data_(const std::vector<uint8_t> &data);
     void handle_mode_data_(const std::vector<uint8_t> &data);
+    // Build a Wavin custom-function-code read PDU (function code + two 16-bit args) and queue it.
+    void send_read_(uint8_t function_code, uint16_t arg1, uint16_t arg2);
 
-    GPIOPin *rw_pin_;
     int channel_ = -1;
     int state_ = 0;
     int element_ = 0;


### PR DESCRIPTION
## Problem

The `wavinAhc9000` component no longer builds/runs on recent ESPHome (tested on **2026.7.2**). Two independent breakages:

1. **Climate traits** — `ClimateTraits::set_supports_current_temperature()` was removed in the 2026.5 "boolean accessors → feature flags" migration, so `climate/wavinAhc9000_climate.cpp` fails to compile:
   ```
   error: 'class esphome::climate::ClimateTraits' has no member named 'set_supports_current_temperature'
   ```
2. **Modbus core rewrite** — sends now go through `create_client_pdu()`, which only accepts the standard function codes and rejects the Wavin's proprietary `0x43/0x44/0x45`:
   ```
   [E][modbus_helpers]: Unsupported function code 43 for client PDU creation
   [D][wavin]: Timeout on channel N, state 1   (every channel, no data)
   ```
   The old `ModbusDevice::send(function_code, …)` path is what triggers this.

The same climate fix was already applied to the `sentio` and `balboa_spa` components; this brings `wavinAhc9000` in line and additionally ports its custom-function-code modbus usage.

## Changes

- **climate:** `set_supports_current_temperature(true)` → `add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE)`.
- **wavinAhc9000:** subclass `modbus::ModbusClientDevice`; build the `0x43/0x44/0x45` PDUs by hand and send them via `send_pdu()` (which queues raw PDUs without function-code validation) instead of the removed `send(function_code, …)` helper.
- Parse responses in `on_modbus_data()` — the rewritten core strips address **and** function code before the callback (custom codes get `server_frame_data_offset() == 2`), so the payload is `[byte_count][payload…]`; skip one byte. `on_modbus_no_response()` advances/skips a stalled channel.
- RS-485 direction control moves from the component's `rw_pin` to the modbus hub's `flow_control_pin`. Sends are now queued/async, so the component can no longer toggle the DE pin around a raw UART write. `rw_pin` is accepted-but-ignored (with a warning) for config backward-compatibility.

## ⚠️ Breaking config change

The DE pin moves to the `modbus:` hub:

```yaml
modbus:
  uart_id: uart_modbus
  flow_control_pin: GPIO26        # was: wavinAhc9000 -> rw_pin
  # optional, tune to taste:
  send_wait_time: 500ms
  turnaround_time: 50ms

wavinAhc9000:
  update_interval: 5s
  # rw_pin removed
```

## Testing

Flashed on a real AHC-9000 (ESP32 pico32) on ESPHome 2026.7.2. All 11 configured channels report temperature, battery, target temperature and mode; setpoint writes from HA work. Occasional per-channel timeouts appear under the conservative default timings but self-recover on the next poll (tunable via `send_wait_time` / `turnaround_time`).

## Note on future ESPHome compatibility

This targets the **2026.7.x** modbus API, where `ModbusClientDevice` exposes `on_modbus_data()` / `on_modbus_no_response()` / `on_modbus_not_sent()`. On ESPHome `dev` these hooks are being renamed to `on_response()` / `on_no_response()` / `on_not_sent()` (the old names kept as deprecated forwards, slated for removal around 2027.2.0), and the response payload is delivered as a `std::span`. So a follow-up will be needed once that lands in a release — a mechanical rename of the three overrides plus the payload accessor, not another redesign. Flagging it here so it's on the radar; happy to submit that follow-up when the API ships if useful.

Happy to adjust naming/structure or split the climate and modbus fixes into separate commits if you'd prefer.