### PR TITLE
Genvexv2: Port select to the ESPHome 2026.8 modbus_controller API

### DIFF
--- a/components/genvexv2/select/genvexv2_select.cpp
+++ b/components/genvexv2/select/genvexv2_select.cpp
@@ -7,44 +7,34 @@ namespace genvexv2 {
 static const char *TAG = "genvexv2.select";
 
 using modbus_controller::ModbusCommandItem;
-using modbus_controller::ModbusRegisterType;
 
-void Genvexv2Select::parse_and_publish(const std::vector<uint8_t> &data) {
-  float received_value = payload_to_float(data, *this);
+void Genvexv2Select::parse_and_publish(std::span<const uint8_t> data) {
+  float received_value = modbus_controller::payload_to_float(data, *this, this->offset);
   ESP_LOGD(TAG, "Genvexv2 Select index: %f", received_value);
 
-  const auto &options = traits.get_options();
+  const auto &options = this->traits.get_options();
 
   if (received_value >= 0 && received_value < options.size()) {
     const auto index = static_cast<size_t>(received_value);
-    const std::string &select_value = options[index];
-    ESP_LOGD(TAG, "Select new state : %s", select_value.c_str());
-    this->publish_state(select_value);
+    ESP_LOGD(TAG, "Select new state : %s", options[index]);
+    this->publish_state(index);
   }
 }
 
-void Genvexv2Select::control(const std::string &value) {
-  ESP_LOGD(TAG, "Genvexv2 Select state: %s", value.c_str());
+void Genvexv2Select::control(size_t index) {
+  const uint16_t speed = static_cast<uint16_t>(index);
+  ESP_LOGD(TAG, "Genvexv2 Select state: %s - WRITING INDEX: %zu (speed: %u)", this->option_at(index), index, speed);
 
-  const auto &options = traits.get_options();
+  auto write_cmd =
+      ModbusCommandItem::create_write_single_command(this->modbus_controller_, this->write_address(), speed);
 
-  for (size_t i = 0; i < options.size(); ++i) {
-    if (value == options[i]) {
-      uint16_t speed = static_cast<uint16_t>(i);
-      ESP_LOGD(TAG, "WRITING INDEX: %d (speed: %u)", i, speed);
-      //auto write_cmd = ModbusCommandItem::create_write_multiple_command(modbus_controller_, this->start_address + this->offset, this->register_count, data);
-      auto write_cmd = ModbusCommandItem::create_write_single_command(modbus_controller_, this->start_address, speed);
-
-      // publish new value
-      write_cmd.on_data_func = 
-      [this, write_cmd, value](ModbusRegisterType register_type, uint16_t start_address, const std::vector<uint8_t> &data) {
-        // gets called when the write command is ack'd from the device
-        modbus_controller_->on_write_register_response(write_cmd.register_type, start_address, data);
-        this->publish_state(value);
-      };
-      modbus_controller_->queue_command(write_cmd);
-    }
-  }
+  // publish new value once the device ack's the write
+  write_cmd.on_data_func = [this, index](modbus::EntityType register_type, uint16_t start_address,
+                                         std::span<const uint8_t> data) {
+    this->modbus_controller_->on_write_register_response(register_type, start_address, data);
+    this->publish_state(index);
+  };
+  this->modbus_controller_->queue_command(std::move(write_cmd));
 }
 
 } // namespace genvexv2

--- a/components/genvexv2/select/genvexv2_select.h
+++ b/components/genvexv2/select/genvexv2_select.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <span>
+
 #include "esphome/core/component.h"
 #include "esphome/components/select/select.h"
 #include "esphome/components/modbus_controller/modbus_controller.h"
@@ -10,16 +12,15 @@ namespace genvexv2 {
 using modbus_controller::ModbusController;
 using modbus_controller::SensorItem;
 using modbus_controller::SensorValueType;
-using modbus_controller::ModbusRegisterType;
 
 class Genvexv2Select : public select::Select, public Component, public SensorItem {
 public:
   Genvexv2Select(uint16_t start_address, uint8_t offset, uint32_t bitmask, SensorValueType value_type, 
               int register_count, uint8_t skip_updates, bool force_new_range)
       : select::Select(), Component(), SensorItem() {
-    this->register_type = ModbusRegisterType::HOLDING;
-    this->start_address = start_address;
-    this->offset = offset;
+    this->register_type = modbus::EntityType::HOLDING;
+    this->set_address(start_address);
+    this->set_offset_from_start_address(offset);
     this->bitmask = bitmask;
     this->sensor_value_type = value_type;
     this->register_count = register_count;
@@ -27,13 +28,13 @@ public:
     this->force_new_range = force_new_range;
   };
 
-  void parse_and_publish(const std::vector<uint8_t> &data) override;
+  void parse_and_publish(std::span<const uint8_t> data) override;
   void set_parent(ModbusController *modbus_controller) { this->modbus_controller_ = modbus_controller; }
 
 protected:
-  modbus_controller::ModbusController *modbus_controller_;
+  modbus_controller::ModbusController *modbus_controller_{nullptr};
 
-  void control(const std::string &value) override;
+  void control(size_t index) override;
 };
 } // namespace genvexv2
 } // namespace esphome


### PR DESCRIPTION
## What

Ports `components/genvexv2/select` to the `modbus_controller` API in ESPHome 2026.8.0. Configs using the `genvexv2` select platform currently fail to compile.

## The errors

```
genvexv2_select.h:30:8: error: 'void esphome::genvexv2::Genvexv2Select::parse_and_publish(
  const std::vector<unsigned char>&)' marked 'override', but does not override
genvexv2_select.cpp:42:66: error: invalid use of non-static member function
  'esphome::modbus::EntityType esphome::modbus_controller::ModbusCommandItem::register_type() const'
genvexv2_select.cpp:44:7: error: no match for 'operator=' (operand types are
  'std::function<void(esphome::modbus::EntityType, short unsigned int,
  std::span<const unsigned char>)>' and ...)
```

## Changes

- `parse_and_publish` takes `std::span<const uint8_t>` — response payloads are no longer `const std::vector<uint8_t> &`.
- `on_data_func` uses the new `void(modbus::EntityType, uint16_t, std::span<const uint8_t>)` signature and reads `register_type` from its own parameter. `ModbusCommandItem` is now a `modbus::ModbusClientDevice` with copy-assignment deleted, so it can't be captured by value inside its own callback.
- `ModbusRegisterType::HOLDING` → `modbus::EntityType::HOLDING`, and `payload_to_float()` takes an explicit offset. Both old forms are deprecated.
- `set_address()` / `set_offset_from_start_address()` replace the direct `start_address` / `offset` assignments, so `range_start_address` and `offset_from_start_address` are seeded for range building.
- `control(size_t)` replaces `control(const std::string &)` — the base class resolves the string path to the index form.

Builds and runs on ESPHome 2026.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)